### PR TITLE
Add the register_url endpoint

### DIFF
--- a/higlass/client.py
+++ b/higlass/client.py
@@ -7,6 +7,7 @@ track_default_positions = {
     'heatmap': 'center',
     'horizontal-heatmap': 'top',
     'osm-tiles': 'center',
+    'horizontal-bar': 'top'
 }
 
 class Track:

--- a/higlass/client.py
+++ b/higlass/client.py
@@ -32,6 +32,13 @@ class Track:
             The height of the track (in pixels)
         width: int 
             The width of the track (in pixels)
+        server: string
+            The server name (usually just 'localhost')
+        file_url: string
+            An http accessible tileset file
+        filetype: string
+            The type of the remote tilesets (e.g. 'bigwig' or
+            'cooler')
         options: {} 
             The options to pass onto the track
         '''

--- a/higlass/client.py
+++ b/higlass/client.py
@@ -11,7 +11,10 @@ track_default_positions = {
 }
 
 class Track:
-    def __init__(self, track_type, position=None, tileset=None, height=None, width=None, options={}):
+    def __init__(self, track_type, position=None, 
+        tileset=None, height=None, width=None, 
+        server=None, file_url=None, filetype=None,
+        options={}):
         '''
         Add a track to a position.
         
@@ -39,6 +42,12 @@ class Track:
 
         if tileset is not None:
             new_track['tilesetUid'] = tileset.uuid
+        if (server is not None 
+            and file_url is not None
+            and filetype is not None):
+            new_track['server'] = server
+            new_track['fileUrl'] = file_url
+            new_track['filetype'] = filetype
         if height is not None:
             new_track['height'] = height
         if width is not None:

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -176,8 +176,6 @@ def create_app(tilesets, name, log_file, log_level, file_ids):
         extract_uuid = lambda tid: tid.split('.')[0]
         uuids_to_tids = toolz.groupby(extract_uuid, tids_requested)
 
-        print("TILESETS:", TILESETS)
-
         tiles = []
         for uuid, tids in uuids_to_tids.items():
             ts = next((ts for ts in list_tilesets() if ts.uuid == uuid), None)
@@ -325,7 +323,6 @@ class Server:
             self.processes[puid].terminate()
             del self.processes[puid]
 
-        print('self.tilesets:', self.tilesets)
         self.app = create_app(
             self.tilesets,
             __name__,

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -277,6 +277,9 @@ class FuseProcess:
 
 
 class Server:
+    '''
+    A lightweight HiGlass server.
+    '''
     # Keep track of the server processes that have been started.
     # So that when someone says 'start', the old ones are terminated
     processes = {}
@@ -288,10 +291,16 @@ class Server:
         '''
         Maintain a reference to a running higlass server
 
-        Parameters:
+        Parameters
         ----------
         port: int
             The port that this server will run on
+        tileset: []
+            A list of tilesets to serve (see higlass.tilesets)
+        host: string
+            The host this server is running on.  Usually just localhost
+        tmp_dir: string
+            A temporary directory into which to mount the http and https files
 
         '''
         self.tilesets = tilesets
@@ -301,7 +310,16 @@ class Server:
         self.file_ids = dict()
 
     def start(self, log_file='/tmp/hgserver.log', log_level=logging.INFO):
+        """
+        Start a lightweight higlass server.
 
+        Parameters
+        ----------
+        log_file: string
+            Where to place diagnostic log files
+        log_level: logging.*
+            What level to log at
+        """
         for puid in list(self.processes.keys()):
             print("terminating:", puid)
             self.processes[puid].terminate()

--- a/higlass/tilesets.py
+++ b/higlass/tilesets.py
@@ -80,5 +80,6 @@ def mmatrix(filepath, uuid=None):
 by_filetype = {
     'cooler': cooler,
     'bigwig': bigwig,
+    'mmatrix': mmatrix,
 }
 

--- a/higlass/tilesets.py
+++ b/higlass/tilesets.py
@@ -77,3 +77,8 @@ def mmatrix(filepath, uuid=None):
                             hgmm.tiles(f, z, x, y)))
     )
 
+by_filetype = {
+    'cooler': cooler,
+    'bigwig': bigwig,
+}
+

--- a/notebooks/Examples.ipynb
+++ b/notebooks/Examples.ipynb
@@ -186,6 +186,261 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "terminating: AyOvZmx5RkCvnEd2jkn-_g\n",
+      "self.tilesets: [<higlass.tilesets.Tileset object at 0x11276c6d8>]\n",
+      " * Serving Flask app \"higlass.server\" (lazy loading)\n",
+      " * Environment: production\n",
+      "   WARNING: Do not use the development server in a production environment.\n",
+      "   Use a production WSGI server instead.\n",
+      " * Debug mode: on\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e7c80e2e6b784f10889241ddbfad5d4c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HiGlassDisplay(viewconf={'editable': True, 'views': [{'uid': 'TVJJD2cqRuaoAG1f3emzPA', 'tracks': {'top': [{'ty…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ts1 = hfti.bigwig('http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig')\n",
+    "\n",
+    "tr1 = hgc.Track('horizontal-bar', tileset=ts1)\n",
+    "view1 = hgc.View([tr1])\n",
+    "(server, display) = higlass.display([view1])\n",
+    "\n",
+    "display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 7.16 ms, sys: 4.13 ms, total: 11.3 ms\n",
+      "Wall time: 11.4 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time \n",
+    "\n",
+    "x = server.tiles(ts1.uuid, 0, 0, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 17.8 ms, sys: 11.5 ms, total: 29.2 ms\n",
+      "Wall time: 2.55 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "import bbi\n",
+    "\n",
+    "a = [bbi.fetch('http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig',\n",
+    "         c, 1, 100000000, 100) \n",
+    "     for c in ['chr1', 'chr2', 'chr3', 'chr4', 'chr5', 'chr6']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 62.9 ms, sys: 169 ms, total: 232 ms\n",
+      "Wall time: 832 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "from multiprocessing import Pool\n",
+    "\n",
+    "p = Pool(16)\n",
+    "\n",
+    "def fun(x):\n",
+    "    import bbi\n",
+    "    \n",
+    "    return bbi.fetch('http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig',\n",
+    "         x, 1, 50000000, 100) \n",
+    "\n",
+    "\n",
+    "chroms = ['chr{}'.format(i) for i in range(1, 16)]\n",
+    "x = p.map(fun, chroms)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 139,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 183 ms, sys: 363 ms, total: 546 ms\n",
+      "Wall time: 6.17 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time \n",
+    "\n",
+    "for chrom in chroms:\n",
+    "    bbi.fetch('http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig',\n",
+    "         chrom, 1, 100000000, 100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 151,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "self.tilesets: []\n",
+      " * Serving Flask app \"higlass.server\" (lazy loading)\n",
+      " * Environment: production\n",
+      "   WARNING: Do not use the development server in a production environment.\n",
+      "   Use a production WSGI server instead.\n",
+      " * Debug mode: on\n",
+      "by_filetype {'cooler': <function cooler at 0x10cd5a488>, 'bigwig': <function bigwig at 0x10cd66a60>} bigwig True\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Traceback (most recent call last):\n",
+      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 2309, in __call__\n",
+      "    return self.wsgi_app(environ, start_response)\n",
+      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 2295, in wsgi_app\n",
+      "    response = self.handle_exception(e)\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/Flask_Cors-3.0.7-py3.6.egg/flask_cors/extension.py\", line 161, in wrapped_function\n",
+      "    return cors_after_request(app.make_response(f(*args, **kwargs)))\n",
+      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 1741, in handle_exception\n",
+      "    reraise(exc_type, exc_value, tb)\n",
+      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/_compat.py\", line 35, in reraise\n",
+      "    raise value\n",
+      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 2292, in wsgi_app\n",
+      "    response = self.full_dispatch_request()\n",
+      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 1815, in full_dispatch_request\n",
+      "    rv = self.handle_user_exception(e)\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/Flask_Cors-3.0.7-py3.6.egg/flask_cors/extension.py\", line 161, in wrapped_function\n",
+      "    return cors_after_request(app.make_response(f(*args, **kwargs)))\n",
+      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 1718, in handle_user_exception\n",
+      "    reraise(exc_type, exc_value, tb)\n",
+      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/_compat.py\", line 35, in reraise\n",
+      "    raise value\n",
+      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 1813, in full_dispatch_request\n",
+      "    rv = self.dispatch_request()\n",
+      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 1799, in dispatch_request\n",
+      "    return self.view_functions[rule.endpoint](**req.view_args)\n",
+      "  File \"/Users/pete/projects/higlass-python/higlass/server.py\", line 63, in register_url\n",
+      "    print(\"tilesets:\", TILESETS)\n",
+      "UnboundLocalError: local variable 'TILESETS' referenced before assignment\n"
+     ]
+    }
+   ],
+   "source": [
+    "import higlass.server as hgse\n",
+    "\n",
+    "s = hgse.Server([])\n",
+    "s.start()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 152,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "JSONDecodeError",
+     "evalue": "Expecting value: line 1 column 1 (char 0)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mJSONDecodeError\u001b[0m                           Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-152-ce88317399f6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      7\u001b[0m                  \u001b[0;34m'filetype'\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m\"bigwig\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      8\u001b[0m              })\n\u001b[0;32m----> 9\u001b[0;31m \u001b[0muid\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mloads\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mret\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcontent\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'uid'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     10\u001b[0m \u001b[0mreq\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrequests\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'http://localhost:{}/api/v1/tileset_info/?d={}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mport\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0muid\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'req'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcontent\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/miniconda3/envs/cenv4/lib/python3.6/json/__init__.py\u001b[0m in \u001b[0;36mloads\u001b[0;34m(s, encoding, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)\u001b[0m\n\u001b[1;32m    352\u001b[0m             \u001b[0mparse_int\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mparse_float\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    353\u001b[0m             parse_constant is None and object_pairs_hook is None and not kw):\n\u001b[0;32m--> 354\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0m_default_decoder\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdecode\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    355\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mcls\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    356\u001b[0m         \u001b[0mcls\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mJSONDecoder\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/miniconda3/envs/cenv4/lib/python3.6/json/decoder.py\u001b[0m in \u001b[0;36mdecode\u001b[0;34m(self, s, _w)\u001b[0m\n\u001b[1;32m    337\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    338\u001b[0m         \"\"\"\n\u001b[0;32m--> 339\u001b[0;31m         \u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mend\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraw_decode\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0midx\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0m_w\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    340\u001b[0m         \u001b[0mend\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_w\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mend\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    341\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mend\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/miniconda3/envs/cenv4/lib/python3.6/json/decoder.py\u001b[0m in \u001b[0;36mraw_decode\u001b[0;34m(self, s, idx)\u001b[0m\n\u001b[1;32m    355\u001b[0m             \u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mend\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mscan_once\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0midx\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    356\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mStopIteration\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0merr\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 357\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mJSONDecodeError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Expecting value\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0ms\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0merr\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    358\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mend\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mJSONDecodeError\u001b[0m: Expecting value: line 1 column 1 (char 0)"
+     ]
+    }
+   ],
+   "source": [
+    "import requests\n",
+    "import json\n",
+    "\n",
+    "ret = requests.post('http://localhost:{}/api/v1/register_url/'.format(s.port),\n",
+    "             json={\n",
+    "                 'url': 'http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig',\n",
+    "                 'filetype': \"bigwig\"\n",
+    "             })\n",
+    "uid = json.loads(ret.content)['uid']\n",
+    "req = requests.get('http://localhost:{}/api/v1/tileset_info/?d={}'.format(s.port, uid))\n",
+    "print('req', req.content)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 124,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "32\n"
+     ]
+    }
+   ],
+   "source": [
+    "import hashlib as hl\n",
+    "m=hl.sha256()\n",
+    "m.update('hi'.encode('utf8'))\n",
+    "print(len(m.digest()))"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],

--- a/notebooks/Examples.ipynb
+++ b/notebooks/Examples.ipynb
@@ -2,9 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 87,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
@@ -13,8 +22,196 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 88,
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "terminating: RvylY4F9SAm_r-0T-KMYdA\n",
+      "self.tilesets: []\n",
+      " * Serving Flask app \"higlass.server\" (lazy loading)\n",
+      " * Environment: production\n",
+      "   WARNING: Do not use the development server in a production environment.\n",
+      "   Use a production WSGI server instead.\n",
+      " * Debug mode: on\n",
+      "TILESETS: []\n",
+      "cids_starts_ends [(0, 0, 249250621), (1, 0, 243199373), (2, 0, 198022430), (3, 0, 191154276), (4, 0, 180915260), (5, 0, 171115067), (6, 0, 159138663), (7, 0, 146364022), (8, 0, 141213431), (9, 0, 135534747), (10, 0, 135006516), (11, 0, 133851895), (12, 0, 115169878), (13, 0, 107349540), (14, 0, 102531392), (15, 0, 90354753), (16, 0, 81195210), (17, 0, 78077248), (18, 0, 59128983), (19, 0, 63025520), (20, 0, 48129895), (21, 0, 51304566), (22, 0, 155270560), (23, 0, 59373566), (24, 0, 16571), (25, 0, 1199273313)]\n",
+      "TILESETS: []\n",
+      "cids_starts_ends [(0, 0, 249250621), (1, 0, 243199373), (2, 0, 198022430), (3, 0, 191154276), (4, 0, 180915260), (5, 0, 171115067), (6, 0, 159138663), (7, 0, 146364022), (8, 0, 141213431), (9, 0, 135534747), (10, 0, 135006516), (11, 0, 133851895), (12, 0, 115169878), (13, 0, 107349540), (14, 0, 102531392), (15, 0, 90354753), (16, 0, 81195210), (17, 0, 78077248), (18, 0, 59128983), (19, 0, 63025520), (20, 0, 48129895), (21, 0, 51304566), (22, 0, 155270560), (23, 0, 59373566), (24, 0, 16571), (25, 0, 1199273313)]\n",
+      "cids_starts_ends [(0, 0, 1024)]\n",
+      "TILESETS: []\n",
+      "cids_starts_ends [(5, 11199864, 171115067), (6, 0, 108520253)]\n",
+      "cids_starts_ends [(4, 57897396, 125006260)]\n",
+      "cids_starts_ends [(0, 0, 249250621), (1, 0, 243199373), (2, 0, 198022430), (3, 0, 191154276), (4, 0, 180915260), (5, 0, 171115067), (6, 0, 159138663), (7, 0, 146364022), (8, 0, 141213431), (9, 0, 135534747), (10, 0, 135006516), (11, 0, 133851895), (12, 0, 62717347)]\n",
+      "cids_starts_ends [(4, 57897396, 180915260), (5, 0, 11199864)]\n",
+      "cids_starts_ends [(4, 125006260, 180915260), (5, 0, 11199864)]\n",
+      "cids_starts_ends [(5, 11199864, 171115067), (6, 0, 159138663), (7, 0, 146364022), (8, 0, 141213431), (9, 0, 135534747), (10, 0, 135006516), (11, 0, 133851895), (12, 0, 62717347)]\n",
+      "cids_starts_ends [(0, 0, 249250621), (1, 0, 243199373), (2, 0, 198022430), (3, 0, 191154276), (4, 0, 180915260), (5, 0, 11199864)]\n",
+      "cids_starts_ends [(3, 114833944, 191154276), (4, 0, 180915260), (5, 0, 11199864)]\n",
+      "cids_starts_ends [(2, 44420918, 198022430), (3, 0, 191154276), (4, 0, 180915260), (5, 0, 11199864)]\n",
+      "cids_starts_ends [(5, 11199864, 171115067), (6, 0, 159138663), (7, 0, 146364022), (8, 0, 71453024)]\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "cids_starts_ends [(4, 125006260, 158560692)]\n",
+      "cids_starts_ends [(4, 125006260, 133394868)]\n",
+      "cids_starts_ends [(4, 91451828, 125006260)]\n",
+      "cids_starts_ends [(4, 125006260, 141783476)]\n",
+      "cids_starts_ends [(4, 133394868, 141783476)]\n",
+      "TILESETS: []\n",
+      "cids_starts_ends [(4, 125006260, 141783476)]\n",
+      "cids_starts_ends [(4, 125006260, 158560692)]\n",
+      "TILESETS: []\n",
+      "cids_starts_ends [(4, 125006260, 133394868)]\n",
+      "cids_starts_ends [(4, 131297716, 132346292)]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Traceback (most recent call last):\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 2309, in __call__\n",
+      "    return self.wsgi_app(environ, start_response)\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 2295, in wsgi_app\n",
+      "    response = self.handle_exception(e)\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask_cors/extension.py\", line 161, in wrapped_function\n",
+      "    return cors_after_request(app.make_response(f(*args, **kwargs)))\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 1741, in handle_exception\n",
+      "    reraise(exc_type, exc_value, tb)\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/_compat.py\", line 35, in reraise\n",
+      "    raise value\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 2292, in wsgi_app\n",
+      "    response = self.full_dispatch_request()\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 1815, in full_dispatch_request\n",
+      "    rv = self.handle_user_exception(e)\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask_cors/extension.py\", line 161, in wrapped_function\n",
+      "    return cors_after_request(app.make_response(f(*args, **kwargs)))\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 1718, in handle_user_exception\n",
+      "    reraise(exc_type, exc_value, tb)\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/_compat.py\", line 35, in reraise\n",
+      "    raise value\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 1813, in full_dispatch_request\n",
+      "    rv = self.dispatch_request()\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 1799, in dispatch_request\n",
+      "    return self.view_functions[rule.endpoint](**req.view_args)\n",
+      "  File \"/Users/pete/projects/higlass-python/higlass/server.py\", line 184, in tiles\n",
+      "    tiles.extend(ts.tiles(tids))\n",
+      "  File \"/Users/pete/projects/higlass-python/higlass/tilesets.py\", line 43, in tiles\n",
+      "    return self.tiles_fn(tile_ids)\n",
+      "  File \"/Users/pete/projects/higlass-python/higlass/tilesets.py\", line 60, in <lambda>\n",
+      "    tiles=lambda tids: hgbi.tiles(filepath, tids, chromsizes=chromsizes),\n",
+      "  File \"/Users/pete/projects/clodius/clodius/tiles/bigwig.py\", line 248, in tiles\n",
+      "    dense = get_bigwig_tile(bwpath, zoom_level, start_pos, end_pos, chromsizes_to_use)\n",
+      "  File \"/Users/pete/projects/clodius/clodius/tiles/bigwig.py\", line 176, in get_bigwig_tile\n",
+      "    pool = mp.Pool(MAX_THREADS)\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/context.py\", line 119, in Pool\n",
+      "    context=self.get_context())\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/pool.py\", line 174, in __init__\n",
+      "    self._repopulate_pool()\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/pool.py\", line 239, in _repopulate_pool\n",
+      "    w.start()\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/process.py\", line 105, in start\n",
+      "    self._popen = self._Popen(self)\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/context.py\", line 277, in _Popen\n",
+      "    return Popen(process_obj)\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/popen_fork.py\", line 20, in __init__\n",
+      "    self._launch(process_obj)\n",
+      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/popen_fork.py\", line 67, in _launch\n",
+      "    self.pid = os.fork()\n",
+      "BlockingIOError: [Errno 35] Resource temporarily unavailable\n"
+     ]
+    }
+   ],
+   "source": [
+    "import higlass.server as hgse\n",
+    "\n",
+    "server = hgse.Server([])\n",
+    "server.start()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "url: http://localhost:52784/api/v1/register_url/\n",
+      "req b'{\\n  \"ZGA_3dPlRtmqmEUlKw5yDg.0.0\": {\\n    \"dense\": \"Rh25PwcCcz+w+bA/HS6MPzbKlD8fw6c/CMrEPw9knT9N2ZA/oMOnP0cmoz+eLIQ/QBeJP2QAcz+dT24/Mf5tP3SLaz/QhC8/QINdP8xZNj82Vnc/G/J8P+8UjT/+7T4/fgRwPxOxLz/khaA/5q6FP98Yfj/A5xFBAADAfwAAwH8AAMB/AADAf+tlB0D5/ZU/F5ydP5zCwD+tPKA/WcFZP4BcjD+wboU/tyBuP80Bjj/Esog/JJkiP22VSD9WxV0/LMuTP3S8qD/wWoE/8WGEPyeqTj9deoI/n0OOP5hSgD9oqZw/394oPyEObT92OVY/8YBXP+UglT/GFVA/cDhvP0alcD9Nh50/POKBP2waVz87f4E/XkmZPwrphT/g8i0/p8h0P7cUkz9o7JU/D+iNP7QLjT+EgzA/0FcnP3BciD/2buU/AlqnP8Gvmz/saF8/uUhbP/NFjz9bc1g/aqFjP9NGRj/3IH4/SSWWP+Efgj/yHjs/IgdnP8K1aj9+MWE/pnRZP2zreD+dATU/wbx9P8R5kT/aO3s/UZtmPwzaRz//Y3Y/75A+P2bwgj+0foY/Rll8P6vLQz8QfYM/6Ip7P4kQdz8slV0/vGyrPzRFYj/LtU4/E75wPzX2iD8zyKA/M+uAP6EKWD8bX1M/ZxOAP0HsXz+234E/peyJP5xfsj9hf54/fv9vP7UofD9LzUY/LS1gP9uZez9kGS0/K/ErP45EED+RHDU/lW8vPwATTD9sOnc/xRhdP8m4TT99ZI4/JRt2Px+Jjj97b5A/DV6HP4knfT8AU3Y/vViJP3N8Mj9/Uow/bYppP2MObz8XxhY/A3o4P8ngkT/xA0I/rYd/P6d8iD8D244/2NFqP+Z2mz8rCoA/8TxeP7ADWT9i9Tk/IFAuP0xbYD+L2RM/Jpk7PxkVrj+naEs/04iWP+FmbD/7yWk/510YP6vVGT96eEQ/NtFbP9oIhz9mgVs/SBtlP6sKaT9FbzE/42QwPzVYbT8I43A/03xiPyTjYz8kAj4/8f5ePy7XLT+diUo/Un0WP+BSWT9df1s/QbWBP5eXcj/+qF0/CVdDP2seQz8eJU0/NVZUP+jEQT/dSCU/G1iKP4DBWD82ElI/y/JaP8bQUT8clCs/I9AYP0uYDT8mJDc/WJ2CP+gAXj+Kzl4/q+ZFPy+QRz8p7nY/jrVrP3e/Xz9fP4Y/NHWCP38Yjj/FUIM/k8w5P6NXiD+7VlM/O5+DPzAEVT8yGCo/RFJ6P86Dcj/ip3U/JaVKPwgjez+f82k/vbe+PxM6nT/GApM/Je1LP+AhnD+dpG8/UUWTP6EURj+kpTs/CGGOP/Dqhj+e2aU/v1yUP7f9ij8H960/nW1qP/srfj+y2q4/S/fFP951sz+/bo0/8tikPxHPRz/IkW0/Ku5rPx9K0z+nLi4/svo0P/s6Yz8ThjU/polRPw81WD/yM40/Ri8iPwfETT/W4y0/akmBP1aDlD/RUWs//QpuP9aSNT8kClQ/VJtyP5f9iT9/CIE/NGaDP631eT/OH2E/ireKP5IPhz9KZFE/QT2JP3fWmD+1qy8/v78iP64SWT/0M5I/UiOAP4cUbT/n/nE/TzJnP/Ooiz9aYVQ/soItP/O1ZT+cOgVAhRdnPyFgVj/oCok/YdhqP5tJNz8CPlU/l1phP9mWZz+Y+ZM/nkeNP0xAiT/6Aks/5kNvP3iQXD97ZkE/CJiVP5V3iD+F3X8/ojCIP7h9Qz/mlII/GExjP9eYNj9TY1k/SXKUP3b9ID9LNFE/z6x+P+YGjj/T+Gg/IRwzP8R5eD+SR9I/LFJeP3TbQj/donQ/g/+EPyLQXT+MsW0/b8h2PzIvPz+WrXE/0ZY7P3gLPz/XtWs/2pF8P1w8qz9mkks/22Y6PzZkJD+kMGk/EqVnP1jhnT8QJ3g/1s1yP3TiYz84jHs/hrGSP3IgFj9lrUI/XgtWP27IPT8IdTA/M1U6P9ynpj/uYJY/RBYWP8lXXj8AAMB/AADAfwAAwH+gCWk/3f8pQOxCYT++A0g/8PVPPxRfOj9S7GA/syGKPz79iD/4z44/FSU/PwBQYj+6XZY/C4NsP8KKZT9PuKI/BNWrP+HooT9BkXQ/ts+FP3ffeD/FDIk/XppDP8zjdT9OrG4/SP6DPx37Vj97Ob0/imz+P14vhD9I/Ig/uNEnPyshRD8vc4k/7QY2P/aHmz+CXJo/xL2DPy0lTz/gU4M/8rmNPyQylj8Le44/RmSfP8ARST/6Oog/5s1kP8bgfD+9z4M/UbREP+cOmj88vnw/I1OWP2jUYT9XlIg/ulc1P9icPT+mbUs/b/6YP5xiFT+OAVE/Y5maP+K5aT+ORDs/D52bP3wZvj98W7s/BXWaP0n3nD+dPFo/RkZ2Pz50ZD+z0lI/GS1uP7nfPz/ILk8/RE59PxdJiT+DqI4/LdeVPwudhj/yy3Y/LG6NPyu4kj9FN5Y/EEmCP8X9KT96T0g/+R+MPw26eT85E18/ygNnP1RrYT9ld50/4WuiP4Fxoj/RijA//EeGP+y1gj/AWTE/LDpUPwNBTj8LYR8/0EtcP404rD9XrW0/DgqJPzxDiz9zsaU/wsyCP4uRiT/J+68/u4pJPwAAwH8AAMB/AADAfwAAwH8Ik0M/y4uAP6vFej/kM4E/zQ1mPwQzTj94XpE/LYKKP/BujD/nbg8/fKUpPzncHD+PwQ8/mCcsP+mzdj9sk04/LVELP0XNCT9RnCo/N29jPxt7gj/SXFE/EgY/PwAAwH8AAMB/AADAfwAAwH8q71M/+5CePzfuGT/0mFA/auRuP2KaLz/e7Aw/fz8jP01djj/qWII/SsZ8P8oikj/8/Z4/W9+jP4QHoD9TR0I/GckRP5XpYz+OYZQ/J3iAP8IWgz8AAMB/AADAfwAAwH8AAMB/hxRhPxX1MT8CrRQ/Y8lqP0CtWz8ev3s/d7SiP9N5VT/yG4g/IMtfP8zfkj+FeJY/3qacP0SPhD9ESKg/3NCOP+fbkj+PwGI/s5KNPx7ZMT+L66k/GFZAPxeHoT+GuZA/wY+BP0Zemj9yioE/v6GyP+PJzD8AAMB/AADAf4vnoD8v22g/NBR6P/aYRj+14Bo/eAGkP0XFjT+PPW8/wQ2EP1syjD98Q6Q/VeyrPzO0aD8BMD8/YXKiPzQthj85pbE/J5mRP1Pglj9U1a8/SYXAPyJvrT/RDUQ/qQySP65Xij/nwo4/2WeFP1Fbgj/Hfb4/IK2NPy91QD+4h4w/gc1pP5yZqj+q6IE/5NghPwG/Wj/+0mM/uCAxPzhVeD/rIYs/xSZVP8m3hT9DN4A/wfAcP0K2Oj9fh0s/3AnBPwJauT9dB6k/6EKpP7RpwD8DvCQ/JO1TP38JlT9FK1Y/phSfP9kvtD8GD6I/AWu7P/PVgT98OZE/ZTpsP9KJSj/tK0E/tkVsP6MyXz+gO4o/8BSyP5P7pD9Goo4/P9GHPyx7mj9vbqI/OddhPyPEbD8AAMB/AADAfzFFO0B8d1s/am1BP2Oo9z69nDY/LDgxP4zJhT/eI4I/rLVkPwAAwH8AAMB/AADAfwAAwH8UKIw/+/SePzNojz/iNoQ/zgeDP98nrT8BIsI/6mqPP+I1cz8+vzk/I2lPP1jmdD9MRWQ/0EpMP+wvKT8axUE/zI8dP9j5aT8dsEk/O1RtP4XvST+s5lQ/9iJUP8FDZT+p4TY/l+9TP34jQT/WcjM/O9gfP21uCz+REAo/LuslPzyTOT+KIz0/HgpcP93cND+vtj8/GKZQP4bdLT+fnkA/0uNXPx/SQj+NKCo/SOkVP9zWTz8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8=\", \\n    \"dtype\": \"float32\", \\n    \"max_value\": 9.119079544037932, \\n    \"min_value\": 0.0\\n  }\\n}\\n'\n",
+      "CPU times: user 12.4 ms, sys: 6.54 ms, total: 19 ms\n",
+      "Wall time: 1.71 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "import requests\n",
+    "import json\n",
+    "\n",
+    "url = 'http://localhost:{}/api/v1/register_url/'.format(server.port)\n",
+    "print('url:', url)\n",
+    "ret = requests.post(url,\n",
+    "             json={\n",
+    "                 'fileUrl': 'http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig',\n",
+    "                 'filetype': \"bigwig\"\n",
+    "             })\n",
+    "uid = json.loads(ret.content)['uid']\n",
+    "url = 'http://localhost:{}/api/v1/tiles/?d={}.0.0'.format(server.port, uid)\n",
+    "req = requests.get(url)\n",
+    "print('req', req.content)\n",
+    "\n",
+    "\"\"\"\n",
+    "url = 'http://localhost:{}/api/v1/tileset_info/?d={}'.format(server.port, uid)\n",
+    "print('url:', url);\n",
+    "req = requests.get(url)\n",
+    "print('req', req.content)\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'{\"editable\": true, \"views\": [{\"uid\": \"T7aKxxjPSPa42lpwW1nBXw\", \"tracks\": {\"top\": [{\"type\": \"horizontal-bar\", \"options\": {}, \"server\": \"http://localhost:52784/api/v1\", \"fileUrl\": \"http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig\", \"filetype\": \"bigwig\"}], \"center\": [], \"left\": [], \"right\": [], \"bottom\": []}, \"layout\": {\"w\": 12, \"h\": 6, \"x\": 0, \"y\": 0}}], \"trackSourceServers\": [\"http://higlass.io/api/v1\"], \"locationLocks\": {\"locksByViewUid\": {}, \"locksDict\": {}}, \"zoomLocks\": {\"locksByViewUid\": {}, \"locksDict\": {}}, \"exportViewUrl\": \"http://higlass.io/api/v1/viewconfs\"}'"
+      ]
+     },
+     "execution_count": 90,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import higlass.client as hgc\n",
+    "import higlass.tilesets as hfti\n",
+    "\n",
+    "ts1 = hfti.bigwig('http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig')\n",
+    "\n",
+    "tr1 = hgc.Track('horizontal-bar', \n",
+    "                server=server.api_address,\n",
+    "                filetype='bigwig',\n",
+    "                file_url='http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig')\n",
+    "view1 = hgc.View([tr1])\n",
+    "vc = hgc.ViewConf([view1])\n",
+    "\n",
+    "import json\n",
+    "json.dumps(vc.to_json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import higlass\n",
@@ -30,38 +227,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "terminating: Y-AitNFTThS05r9g6fcdLg\n",
-      "self.tilesets: [<higlass.tilesets.Tileset object at 0x1122c2f60>]\n",
-      " * Serving Flask app \"higlass.server\" (lazy loading)\n",
-      " * Environment: production\n",
-      "   WARNING: Do not use the development server in a production environment.\n",
-      "   Use a production WSGI server instead.\n",
-      " * Debug mode: on\n",
-      "info: {'bins_per_dimension': 256, 'max_pos': [180, 180], 'max_width': 360, 'max_zoom': 6, 'min_pos': [-180, -180], 'mirror_tiles': 'false'}\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1ffbcffdffbf4e0b8e9a56870a555939",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HiGlassDisplay(viewconf={'editable': True, 'views': [{'uid': 'Zfr05F-BToCGVLEuo-UeKg', 'tracks': {'top': [{'ty…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
    "source": [
     "import higlass.tilesets as hfti\n",
     "\n",
@@ -77,41 +247,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "terminating: G_rkOeq_TA--hdF7DZ_NqA\n",
-      "self.tilesets: [<higlass.tilesets.Tileset object at 0x11271ec18>]\n",
-      " * Serving Flask app \"higlass.server\" (lazy loading)\n",
-      " * Environment: production\n",
-      "   WARNING: Do not use the development server in a production environment.\n",
-      "   Use a production WSGI server instead.\n",
-      " * Debug mode: on\n",
-      "adding: dkei5hkSSQWxl71RRmftlw\n",
-      "adding: Rro0VIg4RgSSOtyrEGstbQ\n",
-      "adding: dkei5hkSSQWxl71RRmftlw\n",
-      "adding: Rro0VIg4RgSSOtyrEGstbQ\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "548565af3fba471ab745be2c3b88e8a8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HiGlassDisplay(viewconf={'editable': True, 'views': [{'uid': 'dkei5hkSSQWxl71RRmftlw', 'tracks': {'top': [{'ty…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
    "source": [
     "height=200\n",
     "\n",
@@ -133,39 +273,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "terminating: ffKQewigQEidGjIWPXLfvw\n",
-      "self.tilesets: [<higlass.tilesets.Tileset object at 0x11271e160>, <higlass.tilesets.Tileset object at 0x11229abe0>]\n",
-      " * Serving Flask app \"higlass.server\" (lazy loading)\n",
-      " * Environment: production\n",
-      "   WARNING: Do not use the development server in a production environment.\n",
-      "   Use a production WSGI server instead.\n",
-      " * Debug mode: on\n",
-      "adding: IOXvvTc0RFygpPI1yUhRGQ\n",
-      "adding: VoFdjoThQgOByd6fv4Fpvw\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3342a976f5904ec1ab23b8d8e916382e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HiGlassDisplay(viewconf={'editable': True, 'views': [{'uid': 'IOXvvTc0RFygpPI1yUhRGQ', 'tracks': {'top': [{'ty…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
    "source": [
     "height=200\n",
     "\n",
@@ -186,37 +298,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "terminating: AyOvZmx5RkCvnEd2jkn-_g\n",
-      "self.tilesets: [<higlass.tilesets.Tileset object at 0x11276c6d8>]\n",
-      " * Serving Flask app \"higlass.server\" (lazy loading)\n",
-      " * Environment: production\n",
-      "   WARNING: Do not use the development server in a production environment.\n",
-      "   Use a production WSGI server instead.\n",
-      " * Debug mode: on\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e7c80e2e6b784f10889241ddbfad5d4c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HiGlassDisplay(viewconf={'editable': True, 'views': [{'uid': 'TVJJD2cqRuaoAG1f3emzPA', 'tracks': {'top': [{'ty…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
    "source": [
     "ts1 = hfti.bigwig('http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig')\n",
     "\n",
@@ -229,18 +315,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 7.16 ms, sys: 4.13 ms, total: 11.3 ms\n",
-      "Wall time: 11.4 s\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
    "source": [
     "%%time \n",
     "\n",
@@ -249,18 +337,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 17.8 ms, sys: 11.5 ms, total: 29.2 ms\n",
-      "Wall time: 2.55 s\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
    "source": [
     "%%time\n",
     "\n",
@@ -273,18 +354,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 62.9 ms, sys: 169 ms, total: 232 ms\n",
-      "Wall time: 832 ms\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
    "source": [
     "%%time\n",
     "from multiprocessing import Pool\n",
@@ -304,18 +378,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 183 ms, sys: 363 ms, total: 546 ms\n",
-      "Wall time: 6.17 s\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
    "source": [
     "%%time \n",
     "\n",
@@ -326,98 +393,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "self.tilesets: []\n",
-      " * Serving Flask app \"higlass.server\" (lazy loading)\n",
-      " * Environment: production\n",
-      "   WARNING: Do not use the development server in a production environment.\n",
-      "   Use a production WSGI server instead.\n",
-      " * Debug mode: on\n",
-      "by_filetype {'cooler': <function cooler at 0x10cd5a488>, 'bigwig': <function bigwig at 0x10cd66a60>} bigwig True\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 2309, in __call__\n",
-      "    return self.wsgi_app(environ, start_response)\n",
-      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 2295, in wsgi_app\n",
-      "    response = self.handle_exception(e)\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/Flask_Cors-3.0.7-py3.6.egg/flask_cors/extension.py\", line 161, in wrapped_function\n",
-      "    return cors_after_request(app.make_response(f(*args, **kwargs)))\n",
-      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 1741, in handle_exception\n",
-      "    reraise(exc_type, exc_value, tb)\n",
-      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/_compat.py\", line 35, in reraise\n",
-      "    raise value\n",
-      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 2292, in wsgi_app\n",
-      "    response = self.full_dispatch_request()\n",
-      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 1815, in full_dispatch_request\n",
-      "    rv = self.handle_user_exception(e)\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/Flask_Cors-3.0.7-py3.6.egg/flask_cors/extension.py\", line 161, in wrapped_function\n",
-      "    return cors_after_request(app.make_response(f(*args, **kwargs)))\n",
-      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 1718, in handle_user_exception\n",
-      "    reraise(exc_type, exc_value, tb)\n",
-      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/_compat.py\", line 35, in reraise\n",
-      "    raise value\n",
-      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 1813, in full_dispatch_request\n",
-      "    rv = self.dispatch_request()\n",
-      "  File \"/Users/pete/projects/hgflask/.eggs/Flask-1.0.2-py3.6.egg/flask/app.py\", line 1799, in dispatch_request\n",
-      "    return self.view_functions[rule.endpoint](**req.view_args)\n",
-      "  File \"/Users/pete/projects/higlass-python/higlass/server.py\", line 63, in register_url\n",
-      "    print(\"tilesets:\", TILESETS)\n",
-      "UnboundLocalError: local variable 'TILESETS' referenced before assignment\n"
-     ]
-    }
-   ],
-   "source": [
-    "import higlass.server as hgse\n",
-    "\n",
-    "s = hgse.Server([])\n",
-    "s.start()"
-   ]
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "JSONDecodeError",
-     "evalue": "Expecting value: line 1 column 1 (char 0)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mJSONDecodeError\u001b[0m                           Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-152-ce88317399f6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      7\u001b[0m                  \u001b[0;34m'filetype'\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m\"bigwig\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      8\u001b[0m              })\n\u001b[0;32m----> 9\u001b[0;31m \u001b[0muid\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mloads\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mret\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcontent\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'uid'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     10\u001b[0m \u001b[0mreq\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrequests\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'http://localhost:{}/api/v1/tileset_info/?d={}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mport\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0muid\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'req'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcontent\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/miniconda3/envs/cenv4/lib/python3.6/json/__init__.py\u001b[0m in \u001b[0;36mloads\u001b[0;34m(s, encoding, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)\u001b[0m\n\u001b[1;32m    352\u001b[0m             \u001b[0mparse_int\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mparse_float\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    353\u001b[0m             parse_constant is None and object_pairs_hook is None and not kw):\n\u001b[0;32m--> 354\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0m_default_decoder\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdecode\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    355\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mcls\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    356\u001b[0m         \u001b[0mcls\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mJSONDecoder\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/miniconda3/envs/cenv4/lib/python3.6/json/decoder.py\u001b[0m in \u001b[0;36mdecode\u001b[0;34m(self, s, _w)\u001b[0m\n\u001b[1;32m    337\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    338\u001b[0m         \"\"\"\n\u001b[0;32m--> 339\u001b[0;31m         \u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mend\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraw_decode\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0midx\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0m_w\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    340\u001b[0m         \u001b[0mend\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_w\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mend\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    341\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mend\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/miniconda3/envs/cenv4/lib/python3.6/json/decoder.py\u001b[0m in \u001b[0;36mraw_decode\u001b[0;34m(self, s, idx)\u001b[0m\n\u001b[1;32m    355\u001b[0m             \u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mend\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mscan_once\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0midx\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    356\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mStopIteration\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0merr\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 357\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mJSONDecodeError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Expecting value\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0ms\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0merr\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    358\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mend\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mJSONDecodeError\u001b[0m: Expecting value: line 1 column 1 (char 0)"
-     ]
-    }
-   ],
-   "source": [
-    "import requests\n",
-    "import json\n",
-    "\n",
-    "ret = requests.post('http://localhost:{}/api/v1/register_url/'.format(s.port),\n",
-    "             json={\n",
-    "                 'url': 'http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig',\n",
-    "                 'filetype': \"bigwig\"\n",
-    "             })\n",
-    "uid = json.loads(ret.content)['uid']\n",
-    "req = requests.get('http://localhost:{}/api/v1/tileset_info/?d={}'.format(s.port, uid))\n",
-    "print('req', req.content)\n",
-    "\n"
-   ]
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -442,7 +441,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }

--- a/notebooks/Examples.ipynb
+++ b/notebooks/Examples.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -22,14 +22,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "terminating: RvylY4F9SAm_r-0T-KMYdA\n",
+      "terminating: afK10q7CSlKc7gsC-ZeejQ\n",
       "self.tilesets: []\n",
       " * Serving Flask app \"higlass.server\" (lazy loading)\n",
       " * Environment: production\n",
@@ -37,90 +37,33 @@
       "   Use a production WSGI server instead.\n",
       " * Debug mode: on\n",
       "TILESETS: []\n",
-      "cids_starts_ends [(0, 0, 249250621), (1, 0, 243199373), (2, 0, 198022430), (3, 0, 191154276), (4, 0, 180915260), (5, 0, 171115067), (6, 0, 159138663), (7, 0, 146364022), (8, 0, 141213431), (9, 0, 135534747), (10, 0, 135006516), (11, 0, 133851895), (12, 0, 115169878), (13, 0, 107349540), (14, 0, 102531392), (15, 0, 90354753), (16, 0, 81195210), (17, 0, 78077248), (18, 0, 59128983), (19, 0, 63025520), (20, 0, 48129895), (21, 0, 51304566), (22, 0, 155270560), (23, 0, 59373566), (24, 0, 16571), (25, 0, 1199273313)]\n",
-      "TILESETS: []\n",
-      "cids_starts_ends [(0, 0, 249250621), (1, 0, 243199373), (2, 0, 198022430), (3, 0, 191154276), (4, 0, 180915260), (5, 0, 171115067), (6, 0, 159138663), (7, 0, 146364022), (8, 0, 141213431), (9, 0, 135534747), (10, 0, 135006516), (11, 0, 133851895), (12, 0, 115169878), (13, 0, 107349540), (14, 0, 102531392), (15, 0, 90354753), (16, 0, 81195210), (17, 0, 78077248), (18, 0, 59128983), (19, 0, 63025520), (20, 0, 48129895), (21, 0, 51304566), (22, 0, 155270560), (23, 0, 59373566), (24, 0, 16571), (25, 0, 1199273313)]\n",
-      "cids_starts_ends [(0, 0, 1024)]\n",
-      "TILESETS: []\n",
-      "cids_starts_ends [(5, 11199864, 171115067), (6, 0, 108520253)]\n",
-      "cids_starts_ends [(4, 57897396, 125006260)]\n",
-      "cids_starts_ends [(0, 0, 249250621), (1, 0, 243199373), (2, 0, 198022430), (3, 0, 191154276), (4, 0, 180915260), (5, 0, 171115067), (6, 0, 159138663), (7, 0, 146364022), (8, 0, 141213431), (9, 0, 135534747), (10, 0, 135006516), (11, 0, 133851895), (12, 0, 62717347)]\n",
-      "cids_starts_ends [(4, 57897396, 180915260), (5, 0, 11199864)]\n",
-      "cids_starts_ends [(4, 125006260, 180915260), (5, 0, 11199864)]\n",
-      "cids_starts_ends [(5, 11199864, 171115067), (6, 0, 159138663), (7, 0, 146364022), (8, 0, 141213431), (9, 0, 135534747), (10, 0, 135006516), (11, 0, 133851895), (12, 0, 62717347)]\n",
-      "cids_starts_ends [(0, 0, 249250621), (1, 0, 243199373), (2, 0, 198022430), (3, 0, 191154276), (4, 0, 180915260), (5, 0, 11199864)]\n",
-      "cids_starts_ends [(3, 114833944, 191154276), (4, 0, 180915260), (5, 0, 11199864)]\n",
-      "cids_starts_ends [(2, 44420918, 198022430), (3, 0, 191154276), (4, 0, 180915260), (5, 0, 11199864)]\n",
-      "cids_starts_ends [(5, 11199864, 171115067), (6, 0, 159138663), (7, 0, 146364022), (8, 0, 71453024)]\n",
       "TILESETS: []\n",
       "TILESETS: []\n",
-      "cids_starts_ends [(4, 125006260, 158560692)]\n",
-      "cids_starts_ends [(4, 125006260, 133394868)]\n",
-      "cids_starts_ends [(4, 91451828, 125006260)]\n",
-      "cids_starts_ends [(4, 125006260, 141783476)]\n",
-      "cids_starts_ends [(4, 133394868, 141783476)]\n",
       "TILESETS: []\n",
-      "cids_starts_ends [(4, 125006260, 141783476)]\n",
-      "cids_starts_ends [(4, 125006260, 158560692)]\n",
       "TILESETS: []\n",
-      "cids_starts_ends [(4, 125006260, 133394868)]\n",
-      "cids_starts_ends [(4, 131297716, 132346292)]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 2309, in __call__\n",
-      "    return self.wsgi_app(environ, start_response)\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 2295, in wsgi_app\n",
-      "    response = self.handle_exception(e)\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask_cors/extension.py\", line 161, in wrapped_function\n",
-      "    return cors_after_request(app.make_response(f(*args, **kwargs)))\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 1741, in handle_exception\n",
-      "    reraise(exc_type, exc_value, tb)\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/_compat.py\", line 35, in reraise\n",
-      "    raise value\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 2292, in wsgi_app\n",
-      "    response = self.full_dispatch_request()\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 1815, in full_dispatch_request\n",
-      "    rv = self.handle_user_exception(e)\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask_cors/extension.py\", line 161, in wrapped_function\n",
-      "    return cors_after_request(app.make_response(f(*args, **kwargs)))\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 1718, in handle_user_exception\n",
-      "    reraise(exc_type, exc_value, tb)\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/_compat.py\", line 35, in reraise\n",
-      "    raise value\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 1813, in full_dispatch_request\n",
-      "    rv = self.dispatch_request()\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/site-packages/flask/app.py\", line 1799, in dispatch_request\n",
-      "    return self.view_functions[rule.endpoint](**req.view_args)\n",
-      "  File \"/Users/pete/projects/higlass-python/higlass/server.py\", line 184, in tiles\n",
-      "    tiles.extend(ts.tiles(tids))\n",
-      "  File \"/Users/pete/projects/higlass-python/higlass/tilesets.py\", line 43, in tiles\n",
-      "    return self.tiles_fn(tile_ids)\n",
-      "  File \"/Users/pete/projects/higlass-python/higlass/tilesets.py\", line 60, in <lambda>\n",
-      "    tiles=lambda tids: hgbi.tiles(filepath, tids, chromsizes=chromsizes),\n",
-      "  File \"/Users/pete/projects/clodius/clodius/tiles/bigwig.py\", line 248, in tiles\n",
-      "    dense = get_bigwig_tile(bwpath, zoom_level, start_pos, end_pos, chromsizes_to_use)\n",
-      "  File \"/Users/pete/projects/clodius/clodius/tiles/bigwig.py\", line 176, in get_bigwig_tile\n",
-      "    pool = mp.Pool(MAX_THREADS)\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/context.py\", line 119, in Pool\n",
-      "    context=self.get_context())\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/pool.py\", line 174, in __init__\n",
-      "    self._repopulate_pool()\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/pool.py\", line 239, in _repopulate_pool\n",
-      "    w.start()\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/process.py\", line 105, in start\n",
-      "    self._popen = self._Popen(self)\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/context.py\", line 277, in _Popen\n",
-      "    return Popen(process_obj)\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/popen_fork.py\", line 20, in __init__\n",
-      "    self._launch(process_obj)\n",
-      "  File \"/Users/pete/miniconda3/envs/cenv4/lib/python3.6/multiprocessing/popen_fork.py\", line 67, in _launch\n",
-      "    self.pid = os.fork()\n",
-      "BlockingIOError: [Errno 35] Resource temporarily unavailable\n"
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n",
+      "TILESETS: []\n"
      ]
     }
    ],
@@ -133,17 +76,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "url: http://localhost:52784/api/v1/register_url/\n",
-      "req b'{\\n  \"ZGA_3dPlRtmqmEUlKw5yDg.0.0\": {\\n    \"dense\": \"Rh25PwcCcz+w+bA/HS6MPzbKlD8fw6c/CMrEPw9knT9N2ZA/oMOnP0cmoz+eLIQ/QBeJP2QAcz+dT24/Mf5tP3SLaz/QhC8/QINdP8xZNj82Vnc/G/J8P+8UjT/+7T4/fgRwPxOxLz/khaA/5q6FP98Yfj/A5xFBAADAfwAAwH8AAMB/AADAf+tlB0D5/ZU/F5ydP5zCwD+tPKA/WcFZP4BcjD+wboU/tyBuP80Bjj/Esog/JJkiP22VSD9WxV0/LMuTP3S8qD/wWoE/8WGEPyeqTj9deoI/n0OOP5hSgD9oqZw/394oPyEObT92OVY/8YBXP+UglT/GFVA/cDhvP0alcD9Nh50/POKBP2waVz87f4E/XkmZPwrphT/g8i0/p8h0P7cUkz9o7JU/D+iNP7QLjT+EgzA/0FcnP3BciD/2buU/AlqnP8Gvmz/saF8/uUhbP/NFjz9bc1g/aqFjP9NGRj/3IH4/SSWWP+Efgj/yHjs/IgdnP8K1aj9+MWE/pnRZP2zreD+dATU/wbx9P8R5kT/aO3s/UZtmPwzaRz//Y3Y/75A+P2bwgj+0foY/Rll8P6vLQz8QfYM/6Ip7P4kQdz8slV0/vGyrPzRFYj/LtU4/E75wPzX2iD8zyKA/M+uAP6EKWD8bX1M/ZxOAP0HsXz+234E/peyJP5xfsj9hf54/fv9vP7UofD9LzUY/LS1gP9uZez9kGS0/K/ErP45EED+RHDU/lW8vPwATTD9sOnc/xRhdP8m4TT99ZI4/JRt2Px+Jjj97b5A/DV6HP4knfT8AU3Y/vViJP3N8Mj9/Uow/bYppP2MObz8XxhY/A3o4P8ngkT/xA0I/rYd/P6d8iD8D244/2NFqP+Z2mz8rCoA/8TxeP7ADWT9i9Tk/IFAuP0xbYD+L2RM/Jpk7PxkVrj+naEs/04iWP+FmbD/7yWk/510YP6vVGT96eEQ/NtFbP9oIhz9mgVs/SBtlP6sKaT9FbzE/42QwPzVYbT8I43A/03xiPyTjYz8kAj4/8f5ePy7XLT+diUo/Un0WP+BSWT9df1s/QbWBP5eXcj/+qF0/CVdDP2seQz8eJU0/NVZUP+jEQT/dSCU/G1iKP4DBWD82ElI/y/JaP8bQUT8clCs/I9AYP0uYDT8mJDc/WJ2CP+gAXj+Kzl4/q+ZFPy+QRz8p7nY/jrVrP3e/Xz9fP4Y/NHWCP38Yjj/FUIM/k8w5P6NXiD+7VlM/O5+DPzAEVT8yGCo/RFJ6P86Dcj/ip3U/JaVKPwgjez+f82k/vbe+PxM6nT/GApM/Je1LP+AhnD+dpG8/UUWTP6EURj+kpTs/CGGOP/Dqhj+e2aU/v1yUP7f9ij8H960/nW1qP/srfj+y2q4/S/fFP951sz+/bo0/8tikPxHPRz/IkW0/Ku5rPx9K0z+nLi4/svo0P/s6Yz8ThjU/polRPw81WD/yM40/Ri8iPwfETT/W4y0/akmBP1aDlD/RUWs//QpuP9aSNT8kClQ/VJtyP5f9iT9/CIE/NGaDP631eT/OH2E/ireKP5IPhz9KZFE/QT2JP3fWmD+1qy8/v78iP64SWT/0M5I/UiOAP4cUbT/n/nE/TzJnP/Ooiz9aYVQ/soItP/O1ZT+cOgVAhRdnPyFgVj/oCok/YdhqP5tJNz8CPlU/l1phP9mWZz+Y+ZM/nkeNP0xAiT/6Aks/5kNvP3iQXD97ZkE/CJiVP5V3iD+F3X8/ojCIP7h9Qz/mlII/GExjP9eYNj9TY1k/SXKUP3b9ID9LNFE/z6x+P+YGjj/T+Gg/IRwzP8R5eD+SR9I/LFJeP3TbQj/donQ/g/+EPyLQXT+MsW0/b8h2PzIvPz+WrXE/0ZY7P3gLPz/XtWs/2pF8P1w8qz9mkks/22Y6PzZkJD+kMGk/EqVnP1jhnT8QJ3g/1s1yP3TiYz84jHs/hrGSP3IgFj9lrUI/XgtWP27IPT8IdTA/M1U6P9ynpj/uYJY/RBYWP8lXXj8AAMB/AADAfwAAwH+gCWk/3f8pQOxCYT++A0g/8PVPPxRfOj9S7GA/syGKPz79iD/4z44/FSU/PwBQYj+6XZY/C4NsP8KKZT9PuKI/BNWrP+HooT9BkXQ/ts+FP3ffeD/FDIk/XppDP8zjdT9OrG4/SP6DPx37Vj97Ob0/imz+P14vhD9I/Ig/uNEnPyshRD8vc4k/7QY2P/aHmz+CXJo/xL2DPy0lTz/gU4M/8rmNPyQylj8Le44/RmSfP8ARST/6Oog/5s1kP8bgfD+9z4M/UbREP+cOmj88vnw/I1OWP2jUYT9XlIg/ulc1P9icPT+mbUs/b/6YP5xiFT+OAVE/Y5maP+K5aT+ORDs/D52bP3wZvj98W7s/BXWaP0n3nD+dPFo/RkZ2Pz50ZD+z0lI/GS1uP7nfPz/ILk8/RE59PxdJiT+DqI4/LdeVPwudhj/yy3Y/LG6NPyu4kj9FN5Y/EEmCP8X9KT96T0g/+R+MPw26eT85E18/ygNnP1RrYT9ld50/4WuiP4Fxoj/RijA//EeGP+y1gj/AWTE/LDpUPwNBTj8LYR8/0EtcP404rD9XrW0/DgqJPzxDiz9zsaU/wsyCP4uRiT/J+68/u4pJPwAAwH8AAMB/AADAfwAAwH8Ik0M/y4uAP6vFej/kM4E/zQ1mPwQzTj94XpE/LYKKP/BujD/nbg8/fKUpPzncHD+PwQ8/mCcsP+mzdj9sk04/LVELP0XNCT9RnCo/N29jPxt7gj/SXFE/EgY/PwAAwH8AAMB/AADAfwAAwH8q71M/+5CePzfuGT/0mFA/auRuP2KaLz/e7Aw/fz8jP01djj/qWII/SsZ8P8oikj/8/Z4/W9+jP4QHoD9TR0I/GckRP5XpYz+OYZQ/J3iAP8IWgz8AAMB/AADAfwAAwH8AAMB/hxRhPxX1MT8CrRQ/Y8lqP0CtWz8ev3s/d7SiP9N5VT/yG4g/IMtfP8zfkj+FeJY/3qacP0SPhD9ESKg/3NCOP+fbkj+PwGI/s5KNPx7ZMT+L66k/GFZAPxeHoT+GuZA/wY+BP0Zemj9yioE/v6GyP+PJzD8AAMB/AADAf4vnoD8v22g/NBR6P/aYRj+14Bo/eAGkP0XFjT+PPW8/wQ2EP1syjD98Q6Q/VeyrPzO0aD8BMD8/YXKiPzQthj85pbE/J5mRP1Pglj9U1a8/SYXAPyJvrT/RDUQ/qQySP65Xij/nwo4/2WeFP1Fbgj/Hfb4/IK2NPy91QD+4h4w/gc1pP5yZqj+q6IE/5NghPwG/Wj/+0mM/uCAxPzhVeD/rIYs/xSZVP8m3hT9DN4A/wfAcP0K2Oj9fh0s/3AnBPwJauT9dB6k/6EKpP7RpwD8DvCQ/JO1TP38JlT9FK1Y/phSfP9kvtD8GD6I/AWu7P/PVgT98OZE/ZTpsP9KJSj/tK0E/tkVsP6MyXz+gO4o/8BSyP5P7pD9Goo4/P9GHPyx7mj9vbqI/OddhPyPEbD8AAMB/AADAfzFFO0B8d1s/am1BP2Oo9z69nDY/LDgxP4zJhT/eI4I/rLVkPwAAwH8AAMB/AADAfwAAwH8UKIw/+/SePzNojz/iNoQ/zgeDP98nrT8BIsI/6mqPP+I1cz8+vzk/I2lPP1jmdD9MRWQ/0EpMP+wvKT8axUE/zI8dP9j5aT8dsEk/O1RtP4XvST+s5lQ/9iJUP8FDZT+p4TY/l+9TP34jQT/WcjM/O9gfP21uCz+REAo/LuslPzyTOT+KIz0/HgpcP93cND+vtj8/GKZQP4bdLT+fnkA/0uNXPx/SQj+NKCo/SOkVP9zWTz8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8AAMB/AADAfwAAwH8=\", \\n    \"dtype\": \"float32\", \\n    \"max_value\": 9.119079544037932, \\n    \"min_value\": 0.0\\n  }\\n}\\n'\n",
-      "CPU times: user 12.4 ms, sys: 6.54 ms, total: 19 ms\n",
-      "Wall time: 1.71 s\n"
+      "url: http://localhost:55640/api/v1/register_url/\n",
+      "CPU times: user 57.4 ms, sys: 32.6 ms, total: 89.9 ms\n",
+      "Wall time: 7.81 s\n"
      ]
     }
    ],
@@ -158,12 +100,14 @@
     "ret = requests.post(url,\n",
     "             json={\n",
     "                 'fileUrl': 'http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig',\n",
+    "                 #'fileUrl': 'http://localhost:8111/wgEncodeCaltechRnaSeqHuvecR1x75dTh1014IlnaPlusSignalRep2.bigWig',\n",
     "                 'filetype': \"bigwig\"\n",
     "             })\n",
     "uid = json.loads(ret.content)['uid']\n",
-    "url = 'http://localhost:{}/api/v1/tiles/?d={}.0.0'.format(server.port, uid)\n",
+    "url = 'http://localhost:{}/api/v1/tiles/?d={}.2.0&d={}.2.1&d={}.2.2'.format(server.port, uid, uid, uid)\n",
+    "#url = \"http://localhost:8111/wgEncodeCaltechRnaSeqHuvecR1x75dTh1014IlnaPlusSignalRep2.bigWig\"\n",
     "req = requests.get(url)\n",
-    "print('req', req.content)\n",
+    "#print('req', req.content)\n",
     "\n",
     "\"\"\"\n",
     "url = 'http://localhost:{}/api/v1/tileset_info/?d={}'.format(server.port, uid)\n",
@@ -175,16 +119,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'{\"editable\": true, \"views\": [{\"uid\": \"T7aKxxjPSPa42lpwW1nBXw\", \"tracks\": {\"top\": [{\"type\": \"horizontal-bar\", \"options\": {}, \"server\": \"http://localhost:52784/api/v1\", \"fileUrl\": \"http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig\", \"filetype\": \"bigwig\"}], \"center\": [], \"left\": [], \"right\": [], \"bottom\": []}, \"layout\": {\"w\": 12, \"h\": 6, \"x\": 0, \"y\": 0}}], \"trackSourceServers\": [\"http://higlass.io/api/v1\"], \"locationLocks\": {\"locksByViewUid\": {}, \"locksDict\": {}}, \"zoomLocks\": {\"locksByViewUid\": {}, \"locksDict\": {}}, \"exportViewUrl\": \"http://higlass.io/api/v1/viewconfs\"}'"
+       "'{\"editable\": true, \"views\": [{\"uid\": \"Cs0jaHTuQXuibqx36Ew1xg\", \"tracks\": {\"top\": [{\"type\": \"horizontal-bar\", \"options\": {}, \"server\": \"http://localhost:55640/api/v1\", \"fileUrl\": \"http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig\", \"filetype\": \"bigwig\"}], \"center\": [], \"left\": [], \"right\": [], \"bottom\": []}, \"layout\": {\"w\": 12, \"h\": 6, \"x\": 0, \"y\": 0}}], \"trackSourceServers\": [\"http://higlass.io/api/v1\"], \"locationLocks\": {\"locksByViewUid\": {}, \"locksDict\": {}}, \"zoomLocks\": {\"locksByViewUid\": {}, \"locksDict\": {}}, \"exportViewUrl\": \"http://higlass.io/api/v1/viewconfs\"}'"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -320,15 +264,6 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
    "source": [
     "%%time \n",
     "\n",
@@ -436,6 +371,149 @@
     "m=hl.sha256()\n",
     "m.update('hi'.encode('utf8'))\n",
     "print(len(m.digest()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Random tests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "1201040023124343\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "42313142\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from concurrent.futures import ThreadPoolExecutor\n",
+    "\n",
+    "def f1(x):\n",
+    "    print(x)\n",
+    "    \n",
+    "def f2(y):\n",
+    "    with ThreadPoolExecutor(max_workers=4) as e:\n",
+    "        r = e.map(f1, range(5))\n",
+    "    \n",
+    "def f3():\n",
+    "    with ThreadPoolExecutor(max_workers=4) as e:\n",
+    "        r = e.map(f2, range(5))\n",
+    "    \n",
+    "f3()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Barrier',\n",
+       " 'BoundedSemaphore',\n",
+       " 'BrokenBarrierError',\n",
+       " 'Condition',\n",
+       " 'Event',\n",
+       " 'Lock',\n",
+       " 'RLock',\n",
+       " 'Semaphore',\n",
+       " 'TIMEOUT_MAX',\n",
+       " 'Thread',\n",
+       " 'ThreadError',\n",
+       " 'Timer',\n",
+       " 'WeakSet',\n",
+       " '_CRLock',\n",
+       " '_DummyThread',\n",
+       " '_MainThread',\n",
+       " '_PyRLock',\n",
+       " '_RLock',\n",
+       " '__all__',\n",
+       " '__builtins__',\n",
+       " '__cached__',\n",
+       " '__doc__',\n",
+       " '__file__',\n",
+       " '__loader__',\n",
+       " '__name__',\n",
+       " '__package__',\n",
+       " '__spec__',\n",
+       " '_active',\n",
+       " '_active_limbo_lock',\n",
+       " '_after_fork',\n",
+       " '_allocate_lock',\n",
+       " '_count',\n",
+       " '_counter',\n",
+       " '_dangling',\n",
+       " '_deque',\n",
+       " '_enumerate',\n",
+       " '_format_exc',\n",
+       " '_islice',\n",
+       " '_limbo',\n",
+       " '_main_thread',\n",
+       " '_newname',\n",
+       " '_pickSomeNonDaemonThread',\n",
+       " '_profile_hook',\n",
+       " '_set_sentinel',\n",
+       " '_shutdown',\n",
+       " '_start_new_thread',\n",
+       " '_sys',\n",
+       " '_time',\n",
+       " '_trace_hook',\n",
+       " 'activeCount',\n",
+       " 'active_count',\n",
+       " 'currentThread',\n",
+       " 'current_thread',\n",
+       " 'enumerate',\n",
+       " 'get_ident',\n",
+       " 'local',\n",
+       " 'main_thread',\n",
+       " 'setprofile',\n",
+       " 'settrace',\n",
+       " 'stack_size']"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import threading as th\n",
+    "dir(th)"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+cytoolz
+multiprocess
+flask
+flask-cors
+fuse
+fusepy
+sh


### PR DESCRIPTION
This PR creates the `register_url` endpoint in `higlass.server`. With this endpoint, one need not register tilesets before viewing them in the client.

See also: https://github.com/higlass/higlass/pull/427