### PR TITLE
Rename to higlass-python for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This package provide access to:
 
 ### Requirements
 
-- Python >= 3.6
+- Python >= 3.7
+- [FUSE](https://github.com/libfuse/libfuse) or [MacFuse](https://osxfuse.github.io/)
 - Jupyter Notebook >= 5.7
 - Jupyter Lab >= 0.35
 
@@ -31,12 +32,9 @@ pip install higlass-python
 Open a terminal and execute the following code to activate the integration:
 
 ```bash
-# Only required if you have not enabled the ipywidgets nbextension yet
+# The following is only required if you have not enabled the ipywidgets nbextension yet
 jupyter nbextension enable --py --sys-prefix widgetsnbextension
-
-# For notebook
-jupyter nbextension enable --py --sys-prefix higlass-jupyter
-
+jupyter nbextension enable --py --sys-prefix higlass
 ```
 
 #### Jupyter notebook integration
@@ -44,10 +42,8 @@ jupyter nbextension enable --py --sys-prefix higlass-jupyter
 Open a terminal and execute the following code to activate the integration:
 
 ```bash
-# Only required if you have not enabled the jupyterlab manager yet
+# The following is only required if you have not enabled the jupyterlab manager yet
 jupyter labextension install @jupyter-widgets/jupyterlab-manager
-
-# For lab
 jupyter labextension install higlass-jupyter
 ```
 
@@ -68,8 +64,8 @@ Take a look at [notebooks/Examples.ipynb](notebooks/Examples.ipynb) on how to ge
    ```bash
    python setup.py jsdeps
    jupyter nbextension enable --py --sys-prefix widgetsnbextension
-   jupyter nbextension install --py --symlink --sys-prefix higlass-jupyter
-   jupyter nbextension enable --py --sys-prefix higlass-jupyter
+   jupyter nbextension install --py --symlink --sys-prefix higlass
+   jupyter nbextension enable --py --sys-prefix higlass
    ```
 
 * Uninstall the Jupyter Notebook Extension

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 [![Docs](https://img.shields.io/badge/docs-🎉-red.svg?colorB=6680ff)](https://higlass.io/docs/python_api.html)
 [![Python](https://img.shields.io/badge/python-😍-red.svg?colorB=af80ff)](https://higlass.io/docs/python_api.html)
 
-Python bindings to the HiGlass viewer.
+Python bindings to the HiGlass for tile serving, view config generation, and Jupyter Notebook + Lab integration.
+
+This package provide access to:
+- server: a lightweight flask server
+- tilesets: tileset API
+- client: an API for generating view configs
+- viewer: an API for launching HiGlass in Jupyter Notebook or Lab
 
 ### Requirements
 
@@ -20,25 +26,29 @@ First install `higlass-python` via pip:
 pip install higlass-python
 ```
 
-If you're using **Jupyter Notebook**, open a terminal and execute the following code to activate the integrations:
+#### Jupyter notebook integration
+
+Open a terminal and execute the following code to activate the integration:
 
 ```bash
 # Only required if you have not enabled the ipywidgets nbextension yet
 jupyter nbextension enable --py --sys-prefix widgetsnbextension
 
 # For notebook
-jupyter nbextension enable --py --sys-prefix higlass
+jupyter nbextension enable --py --sys-prefix higlass-jupyter
 
 ```
 
-If you're using **Jupyter Lab**, open a terminal and execute the following code to activate the integrations:
+#### Jupyter notebook integration
+
+Open a terminal and execute the following code to activate the integration:
 
 ```bash
 # Only required if you have not enabled the jupyterlab manager yet
 jupyter labextension install @jupyter-widgets/jupyterlab-manager
 
 # For lab
-jupyter labextension install higlass
+jupyter labextension install higlass-jupyter
 ```
 
 ### Getting started
@@ -58,8 +68,8 @@ Take a look at [notebooks/Examples.ipynb](notebooks/Examples.ipynb) on how to ge
    ```bash
    python setup.py jsdeps
    jupyter nbextension enable --py --sys-prefix widgetsnbextension
-   jupyter nbextension install --py --symlink --sys-prefix higlass
-   jupyter nbextension enable --py --sys-prefix higlass
+   jupyter nbextension install --py --symlink --sys-prefix higlass-jupyter
+   jupyter nbextension enable --py --sys-prefix higlass-jupyter
    ```
 
 * Uninstall the Jupyter Notebook Extension

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,25 @@
+name: hg-jupyter
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+
+dependencies:
+  - python=3.7
+  - nodejs
+  - multiprocess
+  - fusepy
+  - cython
+  - cytoolz
+  - sh
+  - jupyterlab
+  - flask
+  - flask-cors
+  - ipython
+  - ipywidgets
+  - requests
+  - pip
+  - pip:
+      - clodius
+      - slugid
+      - simple-httpfs

--- a/examples/simple-example.ipynb
+++ b/examples/simple-example.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simple example to get started"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "self.diskcache_directory /tmp/hgflask/dc True\n",
+      "starting fuse\n",
+      "terminating: bJ3uDChYQvikMoXSvChGnQ\n",
+      " * Serving Flask app \"higlass.server\" (lazy loading)\n",
+      " * Environment: production\n",
+      "   WARNING: Do not use the development server in a production environment.\n",
+      "   Use a production WSGI server instead.\n",
+      " * Debug mode: on\n",
+      "<class 'higlass.widgets.HiGlassDisplay'>\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c3ed68a4255f44ae83805e1b4ac7ec7c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HiGlassDisplay(viewconf={'editable': True, 'views': [{'uid': 'MKjC7l9cQH6yU2KX0iHECA', 'tracks': {'top': [{'ty…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import higlass\n",
+    "import higlass.client as hgc\n",
+    "\n",
+    "view1 = hgc.View([\n",
+    "    hgc.Track(track_type='top-axis', position='top'),\n",
+    "    hgc.Track(track_type='heatmap', position='center',\n",
+    "             tileset_uuid='CQMd6V_cRw6iCI_-Unl3PQ',\n",
+    "              server=\"http://higlass.io/api/v1/\",\n",
+    "              height=250,\n",
+    "             options={ 'valueScaleMax': 0.5 }),\n",
+    "\n",
+    "])\n",
+    "\n",
+    "display, server, viewconf = higlass.display([view1])\n",
+    "display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/higlass/__init__.py
+++ b/higlass/__init__.py
@@ -4,8 +4,8 @@ def _jupyter_nbextension_paths():
     return [{
         'section': 'notebook',
         'src': 'static',
-        'dest': 'jupyter-higlass',
-        'require': 'jupyter-higlass/extension'
+        'dest': 'higlass-python',
+        'require': 'higlass-python/extension'
     }]
 
 from ._version import get_versions

--- a/higlass/__init__.py
+++ b/higlass/__init__.py
@@ -4,8 +4,8 @@ def _jupyter_nbextension_paths():
     return [{
         'section': 'notebook',
         'src': 'static',
-        'dest': 'higlass-python',
-        'require': 'higlass-python/extension'
+        'dest': 'higlass-jupyter',
+        'require': 'higlass-jupyter/extension'
     }]
 
 from ._version import get_versions

--- a/higlass/client.py
+++ b/higlass/client.py
@@ -130,7 +130,7 @@ class View:
             The uid of new view
         """
         if uid is None:
-            uid = slugid.nice().decode("utf8")
+            uid = slugid.nice()
 
         self.tracks = tracks
         self.uid = uid
@@ -203,7 +203,7 @@ class ViewConf:
         pass
 
     def add_sync(self, locks_name, views_to_sync):
-        lock_id = slugid.nice().decode("utf-8")
+        lock_id = slugid.nice()
         for view_uid in [v.uid for v in views_to_sync]:
             print("adding:", view_uid)
 

--- a/higlass/client.py
+++ b/higlass/client.py
@@ -3,22 +3,32 @@ import slugid
 
 
 track_default_positions = {
-    'top-axis': 'top',
-    'horizontal-line': 'top',
-    'heatmap': 'center',
-    'horizontal-heatmap': 'top',
-    'osm-tiles': 'center',
-    'horizontal-bar': 'top'
+    "top-axis": "top",
+    "horizontal-line": "top",
+    "heatmap": "center",
+    "horizontal-heatmap": "top",
+    "osm-tiles": "center",
+    "horizontal-bar": "top",
 }
 
 
 class Track:
-    def __init__(self, track_type, position=None, 
-        tileset=None, api_url=None, height=None, width=None, 
-        tileset_uuid=None, server=None, file_url=None, filetype=None,
-        options={}):
+    def __init__(
+        self,
+        track_type,
+        position=None,
+        tileset=None,
+        api_url=None,
+        height=None,
+        width=None,
+        tileset_uuid=None,
+        server=None,
+        file_url=None,
+        filetype=None,
+        options={},
+    ):
 
-        '''
+        """
         Add a track to a position.
 
         Parameters
@@ -42,39 +52,35 @@ class Track:
         filetype: string
             The type of the remote tilesets (e.g. 'bigwig' or
             'cooler')
-        options: {} 
+        options: {}
 
             The options to pass onto the track
-        '''
-        new_track = {
-            'type': track_type,
-            'options': options
-        }
+        """
+        new_track = {"type": track_type, "options": options}
 
         if tileset is not None:
-            new_track['tilesetUid'] = tileset.uuid
+            new_track["tilesetUid"] = tileset.uuid
 
-        if (server is not None
-            and tileset_uuid is not None):
+        if server is not None and tileset_uuid is not None:
             if tileset is None:
-                new_track['tilesetUid'] = tileset_uuid
-                new_track['server'] = server
+                new_track["tilesetUid"] = tileset_uuid
+                new_track["server"] = server
             else:
-                print("Both a tileset object and server and tileset_uuid " 
-                    + "were provided, using the tileset object", 
-                    file=sys.stderr)
-        if (server is not None 
-            and file_url is not None
-            and filetype is not None):
-            new_track['server'] = server
-            new_track['fileUrl'] = file_url
-            new_track['filetype'] = filetype
+                print(
+                    "Both a tileset object and server and tileset_uuid "
+                    + "were provided, using the tileset object",
+                    file=sys.stderr,
+                )
+        if server is not None and file_url is not None and filetype is not None:
+            new_track["server"] = server
+            new_track["fileUrl"] = file_url
+            new_track["filetype"] = filetype
         if height is not None:
-            new_track['height'] = height
+            new_track["height"] = height
         if width is not None:
-            new_track['width'] = width
+            new_track["width"] = width
         if api_url is not None:
-            new_track['server'] = api_url
+            new_track["server"] = api_url
 
         if position is None:
             if track_type in track_default_positions:
@@ -89,14 +95,18 @@ class Track:
 
 
 class View:
-    def __init__(self, tracks=[],
-                 x=0, y=0,
-                 width=12,
-                 height=6,
-                 initialXDomain=None,
-                 initialYDomain=None,
-                 uid=None):
-        '''
+    def __init__(
+        self,
+        tracks=[],
+        x=0,
+        y=0,
+        width=12,
+        height=6,
+        initialXDomain=None,
+        initialYDomain=None,
+        uid=None,
+    ):
+        """
         Add a new view
 
         Parameters
@@ -118,38 +128,26 @@ class View:
             The initial y range of the view
         uid: string
             The uid of new view
-        '''
+        """
         if uid is None:
-            uid = slugid.nice().decode('utf8')
+            uid = slugid.nice().decode("utf8")
 
         self.tracks = tracks
         self.uid = uid
 
         self.viewconf = {
-                'uid': uid,
-                'tracks': {
-                    'top': [],
-                    'center': [],
-                    'left': [],
-                    'right': [],
-                    'bottom': []
-                },
-                "layout": {
-                    "w": width,
-                    "h": height,
-                    "x": x,
-                    "y": y
-                  },
-            }
+            "uid": uid,
+            "tracks": {"top": [], "center": [], "left": [], "right": [], "bottom": []},
+            "layout": {"w": width, "h": height, "x": x, "y": y},
+        }
 
         if initialXDomain is not None:
-            self.viewconf['initialXDomain'] = initialXDomain
+            self.viewconf["initialXDomain"] = initialXDomain
         if initialYDomain is not None:
-            self.viewconf['initialYDomain'] = initialYDomain
-
+            self.viewconf["initialYDomain"] = initialYDomain
 
     def add_track(self, *args, **kwargs):
-        '''
+        """
         Add a track to a position.
 
         Parameters
@@ -166,20 +164,22 @@ class View:
             The height of the track, if it is a top, bottom or a center track
         width: int
             The width of the track, if it is a left, right or a center track
-        '''
+        """
         new_track = Track(*args, **kwargs)
         self.tracks = self.tracks + [new_track]
 
     def to_dict(self):
-        '''
+        """
         Convert the existing track to a JSON representation.
-        '''
+        """
         viewconf = json.loads(json.dumps(self.viewconf))
 
         for track in self.tracks:
             if track.position is None:
-                raise ValueError("Track has no position: {}".format(track.viewconf['type']))
-            viewconf['tracks'][track.position] += [track.to_dict()]
+                raise ValueError(
+                    "Track has no position: {}".format(track.viewconf["type"])
+                )
+            viewconf["tracks"][track.position] += [track.to_dict()]
 
         return viewconf
 
@@ -187,26 +187,12 @@ class View:
 class ViewConf:
     def __init__(self, views=[], location_sync=[], zoom_sync=[]):
         self.viewconf = {
-        'editable': True,
-        'views': [],
-          "trackSourceServers": [
-            "http://higlass.io/api/v1"
-          ],
-          "locationLocks": {
-            "locksByViewUid": {
-
-            },
-            "locksDict": {
-            }
-          },
-          "zoomLocks": {
-            "locksByViewUid": {
-
-            },
-            "locksDict": {
-            }
-          },
-          "exportViewUrl": "http://higlass.io/api/v1/viewconfs"
+            "editable": True,
+            "views": [],
+            "trackSourceServers": ["http://higlass.io/api/v1"],
+            "locationLocks": {"locksByViewUid": {}, "locksDict": {}},
+            "zoomLocks": {"locksByViewUid": {}, "locksDict": {}},
+            "exportViewUrl": "http://higlass.io/api/v1/viewconfs",
         }
 
         self.views = views
@@ -217,25 +203,24 @@ class ViewConf:
         pass
 
     def add_sync(self, locks_name, views_to_sync):
-        lock_id = slugid.nice().decode('utf-8')
+        lock_id = slugid.nice().decode("utf-8")
         for view_uid in [v.uid for v in views_to_sync]:
             print("adding:", view_uid)
 
-            if lock_id not in self.viewconf[locks_name]['locksDict']:
-                self.viewconf[locks_name]['locksDict'][lock_id] = {}
+            if lock_id not in self.viewconf[locks_name]["locksDict"]:
+                self.viewconf[locks_name]["locksDict"][lock_id] = {}
 
-            self.viewconf[locks_name]['locksDict'][lock_id][view_uid] = (1,1,1)
-            self.viewconf[locks_name]['locksByViewUid'][view_uid] = lock_id
+            self.viewconf[locks_name]["locksDict"][lock_id][view_uid] = (1, 1, 1)
+            self.viewconf[locks_name]["locksByViewUid"][view_uid] = lock_id
 
     def add_zoom_sync(self, views_to_sync=[]):
-        self.add_sync('zoomLocks', views_to_sync)
+        self.add_sync("zoomLocks", views_to_sync)
+
     def add_location_sync(self, views_to_sync=[]):
-        self.add_sync('locationLocks', views_to_sync)
-
-
+        self.add_sync("locationLocks", views_to_sync)
 
     def add_view(self, *args, **kwargs):
-        '''
+        """
         Add a new view
 
         Parameters
@@ -255,7 +240,7 @@ class ViewConf:
             The initial x range of the view
         initialYDomain: [int, int]
             The initial y range of the view
-        '''
+        """
         new_view = View(*args, **kwargs)
 
         for view in self.views:
@@ -266,16 +251,15 @@ class ViewConf:
         return new_view
 
     def location_lock(self, view_uid1, view_uid2):
-        '''
+        """
         Add a location lock between two views.
-        '''
+        """
         pass
 
     def to_dict(self):
         viewconf = json.loads(json.dumps(self.viewconf))
 
         for view in self.views:
-            viewconf['views'] += [view.to_dict()]
+            viewconf["views"] += [view.to_dict()]
 
         return viewconf
-

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -358,7 +358,7 @@ class Server:
 
         # we're going to assign a uuid to each server process so that if anything
         # goes wrong, the variable referencing the process doesn't get lost
-        uuid = slugid.nice().decode("utf8")
+        uuid = slugid.nice()
         if self.port is None:
             self.port = get_open_port()
         target = partial(

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -6,16 +6,15 @@ import logging
 import socket
 import json
 import time
-import sys
 import os
 
 from flask import Flask
 from flask import request, jsonify
-#from flask_restful import reqparse, abort, Api, Resource
+
+# from flask_restful import reqparse, abort, Api, Resource
 from flask_cors import CORS
 
 from fuse import FUSE
-import hashlib as hl
 import requests
 import slugid
 import sh
@@ -23,27 +22,28 @@ import sh
 import higlass.tilesets as hgti
 
 
-__all__ = ['Server']
+__all__ = ["Server"]
+
 
 def get_filepath(filepath):
-    '''
+    """
     Get the filepath from a tileset definition
     Parameters
     ----------
     tileset_def: { 'filepath': ..., 'uid': ..., 'filetype': ...}
-        The tileset definition     
+        The tileset definition
     returns: string
         The filepath, either as specified in the tileset_def or
         None
-    '''
-        
-    if filepath[:7] == 'http://':
+    """
+
+    if filepath[:7] == "http://":
         filepath = fuse.http_directory + filepath[6:] + ".."
-    if filepath[:8] == 'https://':
+    if filepath[:8] == "https://":
         filepath = fuse.https_directory + filepath[7:] + ".."
 
     print("******** filepath:", filepath)
-    
+
     return filepath
 
 
@@ -53,37 +53,32 @@ def create_app(tilesets, name, log_file, log_level, file_ids):
 
     TILESETS = tilesets
 
-    remote_tilesets = {
+    remote_tilesets = {}
 
-    }
-
-    @app.route('/api/v1/')
+    @app.route("/api/v1/")
     def hello():
-        return("Hello World!")
+        return "Hello World!"
 
-    @app.route('/api/v1/register_url/', methods=['POST'])
+    @app.route("/api/v1/register_url/", methods=["POST"])
     def register_url():
         js = request.json
-        key = (js['fileUrl'], js['filetype'])
+        key = (js["fileUrl"], js["filetype"])
 
-        if js['filetype'] not in hgti.by_filetype:
-            return jsonify({
-                'error': "Unknown filetype: {}".format(js['filetype'])
-            }),400
+        if js["filetype"] not in hgti.by_filetype:
+            return (
+                jsonify({"error": "Unknown filetype: {}".format(js["filetype"])}),
+                400,
+            )
 
         if key in remote_tilesets:
-            return jsonify({
-                'uid': remote_tilesets[key].uuid
-            })
+            return jsonify({"uid": remote_tilesets[key].uuid})
 
-        new_tileset = hgti.by_filetype[js['filetype']](get_filepath(js['fileUrl']))
+        new_tileset = hgti.by_filetype[js["filetype"]](get_filepath(js["fileUrl"]))
         remote_tilesets[key] = new_tileset
-        
-        return jsonify({
-            'uid': new_tileset.uuid
-        })
 
-    @app.route('/api/v1/chrom-sizes/', methods=['GET'])
+        return jsonify({"uid": new_tileset.uuid})
+
+    @app.route("/api/v1/chrom-sizes/", methods=["GET"])
     def chrom_sizes():
         """
         Coordinate system resource.
@@ -98,9 +93,9 @@ def create_app(tilesets, name, log_file, log_level, file_ids):
             Return cumulative lengths. Default is false.
 
         """
-        uuid = request.args.get('id', None)
-        res_type = request.args.get('type', 'tsv')
-        incl_cum = request.args.get('cum', False)
+        uuid = request.args.get("id", None)
+        res_type = request.args.get("type", "tsv")
+        incl_cum = request.args.get("cum", False)
 
         ts = next((ts for ts in list_tilesets() if ts.uuid == uuid), None)
 
@@ -117,60 +112,63 @@ def create_app(tilesets, name, log_file, log_level, file_ids):
                 new_data += [(chrom, size, cum)]
                 cum += size
 
-            for chrom in data.keys():   # dictionaries in py3.6+ are ordered!
-                data[chrom]['offset'] = cum
-                cum += data[chrom]['size']
+            for chrom in data.keys():  # dictionaries in py3.6+ are ordered!
+                data[chrom]["offset"] = cum
+                cum += data[chrom]["size"]
 
-        if res_type == 'json':
+        if res_type == "json":
             # should return
             # { uuid: {
             #   'chr1': {'size': 2343, 'offset': 0},
             #
             if incl_cum:
                 j = {
-                        ts.uuid: dict([(chrom, { 'size': size, 'offset': offset }) for
-                            (chrom, size, offset) in data])
-                    }
+                    ts.uuid: dict(
+                        [
+                            (chrom, {"size": size, "offset": offset})
+                            for (chrom, size, offset) in data
+                        ]
+                    )
+                }
             else:
-                j = {
-                        ts.uuid: dict([(chrom, { 'size': size }) for
-                            (chrom, size) in data])
-                    }
+                j = {ts.uuid: dict([(chrom, {"size": size}) for (chrom, size) in data])}
             return jsonify(j)
 
-        elif res_type == 'tsv':
+        elif res_type == "tsv":
             if incl_cum:
-               return '\n'.join('{}\t{}\t{}'.format(chrom, size, cum)
-                       for chrom, size, cum in data)
+                return "\n".join(
+                    "{}\t{}\t{}".format(chrom, size, cum) for chrom, size, cum in data
+                )
             else:
-                return '\n'.join('{}\t{}'.format(chrom, size)
-                    for chrom, size in data)
+                return "\n".join("{}\t{}".format(chrom, size) for chrom, size in data)
 
         else:
             return jsonify({"error": "Unknown response type"}), 500
 
-    @app.route('/api/v1/uids_by_filename/', methods=['GET'])
+    @app.route("/api/v1/uids_by_filename/", methods=["GET"])
     def uids_by_filename():
-        return jsonify({
-            "count": len(TILESETS),
-            "results": {i: TILESETS[i] for i in range(len(TILESETS))}
-        })
+        return jsonify(
+            {
+                "count": len(TILESETS),
+                "results": {i: TILESETS[i] for i in range(len(TILESETS))},
+            }
+        )
 
-    @app.route('/api/v1/tilesets/', methods=['GET'])
+    @app.route("/api/v1/tilesets/", methods=["GET"])
     def tilesets():
-        return jsonify({
-            "count": len(TILESETS),
-            "next": None,
-            "previous": None,
-            "results": [ts.meta for ts in TILESETS],
-        })
+        return jsonify(
+            {
+                "count": len(TILESETS),
+                "next": None,
+                "previous": None,
+                "results": [ts.meta for ts in TILESETS],
+            }
+        )
 
     def list_tilesets():
-        return (
-            TILESETS + list(remote_tilesets.values())
-            )
+        return TILESETS + list(remote_tilesets.values())
 
-    @app.route('/api/v1/tileset_info/', methods=['GET'])
+    @app.route("/api/v1/tileset_info/", methods=["GET"])
     def tileset_info():
         uuids = request.args.getlist("d")
 
@@ -181,20 +179,18 @@ def create_app(tilesets, name, log_file, log_level, file_ids):
             if ts is not None:
                 info[uuid] = ts.tileset_info()
             else:
-                info[uuid] = {
-                    'error': 'No such tileset with uid: {}'.format(uuid)
-                }
+                info[uuid] = {"error": "No such tileset with uid: {}".format(uuid)}
 
         return jsonify(info)
 
-    @app.route('/api/v1/tiles/', methods=['GET'])
+    @app.route("/api/v1/tiles/", methods=["GET"])
     def tiles():
         tids_requested = set(request.args.getlist("d"))
 
         if not tids_requested:
-            return jsonify({'error': 'No tiles requested'}), 400
+            return jsonify({"error": "No tiles requested"}), 400
 
-        extract_uuid = lambda tid: tid.split('.')[0]
+        extract_uuid = lambda tid: tid.split(".")[0]
         uuids_to_tids = toolz.groupby(extract_uuid, tids_requested)
 
         tiles = []
@@ -207,7 +203,8 @@ def create_app(tilesets, name, log_file, log_level, file_ids):
     logging.basicConfig(
         level=log_level,
         filename=log_file,
-        format='[%(asctime)s] %(levelname)s in %(module)s: %(message)s')
+        format="[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
+    )
 
     return app
 
@@ -228,12 +225,12 @@ def get_open_port():
 class FuseProcess:
     def __init__(self, tmp_dir):
         self.tmp_dir = tmp_dir
-        self.http_directory = op.join(tmp_dir, 'http')
-        self.https_directory = op.join(tmp_dir, 'https')
-        self.diskcache_directory = op.join(tmp_dir, 'dc')
+        self.http_directory = op.join(tmp_dir, "http")
+        self.https_directory = op.join(tmp_dir, "https")
+        self.diskcache_directory = op.join(tmp_dir, "dc")
 
     def setup(self):
-        '''
+        """
         Set up filesystem in user space for http and https
         so that we can retrieve tiles from remote sources.
 
@@ -242,7 +239,7 @@ class FuseProcess:
         tmp_dir: string
             The temporary directory where to create the
             http and https directories
-        '''
+        """
         from simple_httpfs import HttpFs
 
         if not op.exists(self.http_directory):
@@ -262,21 +259,26 @@ class FuseProcess:
         except Exception as ex:
             pass
 
-        disk_cache_size = 2**25
+        disk_cache_size = 2 ** 25
         disk_cache_dir = self.diskcache_directory
         lru_capacity = 400
-        print("self.diskcache_directory", self.diskcache_directory, op.exists(self.diskcache_directory))
+        print(
+            "self.diskcache_directory",
+            self.diskcache_directory,
+            op.exists(self.diskcache_directory),
+        )
 
         def start_fuse(directory):
             print("starting fuse")
             fuse = FUSE(
-                HttpFs('http',
-                       disk_cache_size=disk_cache_size,
-                       disk_cache_dir=self.diskcache_directory,
-                       lru_capacity=lru_capacity,
-                    ),
+                HttpFs(
+                    "http",
+                    disk_cache_size=disk_cache_size,
+                    disk_cache_dir=self.diskcache_directory,
+                    lru_capacity=lru_capacity,
+                ),
                 directory,
-                foreground=False
+                foreground=False,
             )
 
         proc = mp.Process(target=start_fuse, args=[self.http_directory])
@@ -296,16 +298,17 @@ class FuseProcess:
 
 
 class Server:
-    '''
+    """
     A lightweight HiGlass server.
-    '''
+    """
+
     # Keep track of the server processes that have been started.
     # So that when someone says 'start', the old ones are terminated
     processes = {}
-    diskcache_directory = '/tmp/hgflask/dc'
+    diskcache_directory = "/tmp/hgflask/dc"
 
-    def __init__(self, tilesets, port=None, host='localhost', tmp_dir='/tmp/hgflask'):
-        '''
+    def __init__(self, tilesets, port=None, host="localhost", tmp_dir="/tmp/hgflask"):
+        """
         Maintain a reference to a running higlass server
 
         Parameters
@@ -319,7 +322,7 @@ class Server:
         tmp_dir: string
             A temporary directory into which to mount the http and https files
 
-        '''
+        """
         self.tilesets = tilesets
         self.host = host
         self.port = port
@@ -329,7 +332,7 @@ class Server:
         self.fuse_process = FuseProcess(tmp_dir)
         self.fuse_process.setup()
 
-    def start(self, log_file='/tmp/hgserver.log', log_level=logging.INFO):
+    def start(self, log_file="/tmp/hgserver.log", log_level=logging.INFO):
         """
         Start a lightweight higlass server.
 
@@ -349,100 +352,99 @@ class Server:
             self.tilesets,
             __name__,
             log_file=log_file,
-            log_level=log_level, 
-            file_ids=self.file_ids)
+            log_level=log_level,
+            file_ids=self.file_ids,
+        )
 
         # we're going to assign a uuid to each server process so that if anything
         # goes wrong, the variable referencing the process doesn't get lost
-        uuid = slugid.nice().decode('utf8')
+        uuid = slugid.nice().decode("utf8")
         if self.port is None:
             self.port = get_open_port()
-        target = partial(self.app.run,
-                         threaded=True,
-                         debug=True,
-                         host='0.0.0.0',
-                         port=self.port,
-                         use_reloader=False)
+        target = partial(
+            self.app.run,
+            threaded=True,
+            debug=True,
+            host="0.0.0.0",
+            port=self.port,
+            use_reloader=False,
+        )
         self.processes[uuid] = mp.Process(target=target)
         self.processes[uuid].start()
         self.connected = False
         while not self.connected:
             try:
-                url = 'http://{}:{}/api/v1'.format(self.host, self.port)
+                url = "http://{}:{}/api/v1".format(self.host, self.port)
                 r = requests.head(url)
                 if r.ok:
                     self.connected = True
             except requests.ConnectionError as err:
-                time.sleep(.2)
+                time.sleep(0.2)
 
     def stop(self):
-        '''
+        """
         Stop this server so that the calling process can exit
-        '''
+        """
         # unsetup_fuse()
         for uuid in self.processes:
             self.processes[uuid].terminate()
 
     def tileset_info(self, uid):
-        '''
+        """
         Return the tileset info for the given tileset
-        '''
-        url = 'http://{host}:{port}/api/v1/tileset_info/?d={uid}'.format(
-            host=self.host,
-            port=self.port,
-            uid=uid)
+        """
+        url = "http://{host}:{port}/api/v1/tileset_info/?d={uid}".format(
+            host=self.host, port=self.port, uid=uid
+        )
 
         req = requests.get(url)
         if req.status_code != 200:
-            raise ServerError('Error fetching tileset_info:', req.content)
+            raise ServerError("Error fetching tileset_info:", req.content)
 
         content = json.loads(req.content)
         return content[uid]
 
     def tiles(self, uid, z, x, y=None):
-        '''
+        """
         Return tiles from the specified dataset (uid) at
         the given position (z,x,[u])
-        '''
-        tile_id ='{uid}.{z}.{x}'.format(uid=uid, z=z, x=x)
+        """
+        tile_id = "{uid}.{z}.{x}".format(uid=uid, z=z, x=x)
         if y is not None:
-            tile_id += '.{y}'.format(y=y)
-        url = 'http://{host}:{port}/api/v1/tiles/?d={tile_id}'.format(
-            host=self.host,
-            port=self.port,
-            tile_id=tile_id)
+            tile_id += ".{y}".format(y=y)
+        url = "http://{host}:{port}/api/v1/tiles/?d={tile_id}".format(
+            host=self.host, port=self.port, tile_id=tile_id
+        )
 
         print("url:", url)
 
         req = requests.get(url)
         if req.status_code != 200:
-            raise ServerError('Error fetching tile:', req.content)
+            raise ServerError("Error fetching tile:", req.content)
 
         content = json.loads(req.content)
         return content[tile_id]
 
     def chromsizes(self, uid):
-        '''
+        """
         Return the chromosome sizes from the given filename
-        '''
-        url = 'http://{host}:{port}/api/v1/chrom-sizes/?id={uid}'.format(
-            host=self.host,
-            port=self.port,
-            uid=uid)
+        """
+        url = "http://{host}:{port}/api/v1/chrom-sizes/?id={uid}".format(
+            host=self.host, port=self.port, uid=uid
+        )
 
         req = requests.get(url)
         if req.status_code != 200:
-            raise ServerError('Error fetching chromsizes:', req.content)
+            raise ServerError("Error fetching chromsizes:", req.content)
 
         return req.content
 
     @property
     def api_address(self):
-        return 'http://{host}:{port}/api/v1'.format(
-            host=self.host,
-            port=self.port)
+        return "http://{host}:{port}/api/v1".format(host=self.host, port=self.port)
 
-TMP_DIR='/tmp/higlass-python/'
+
+TMP_DIR = "/tmp/higlass-python/"
 
 fuse = FuseProcess(TMP_DIR)
 fuse.setup()

--- a/higlass/tilesets.py
+++ b/higlass/tilesets.py
@@ -11,12 +11,19 @@ import slugid
 
 
 class Tileset:
-    def __init__(self, tileset_info=None, tiles=None,
-                 chromsizes=lambda: None, uuid=None,
-                 private=False, name='', datatype='',
-                track_type=None,
-                track_position=None):
-        '''
+    def __init__(
+        self,
+        tileset_info=None,
+        tiles=None,
+        chromsizes=lambda: None,
+        uuid=None,
+        private=False,
+        name="",
+        datatype="",
+        track_type=None,
+        track_position=None,
+    ):
+        """
         Parameters
         ----------
         tileset_info: function
@@ -24,7 +31,7 @@ class Tileset:
             for this tileset.
         tiles: function
             A function returning tile data for this tileset
-        '''
+        """
         self.name = name
         self.datatype = datatype
         self.tileset_info_fn = tileset_info
@@ -33,16 +40,16 @@ class Tileset:
         self.private = private
         self.track_type = None
         self.track_position = None
-        
+
         if uuid is not None:
             self.uuid = uuid
         else:
-            self.uuid = slugid.nice().decode('utf-8')
+            self.uuid = slugid.nice().decode("utf-8")
 
     def tileset_info(self):
         return self.tileset_info_fn()
 
-    def tiles(self, tile_ids ):
+    def tiles(self, tile_ids):
         return self.tiles_fn(tile_ids)
 
     def chromsizes(self):
@@ -51,11 +58,11 @@ class Tileset:
     @property
     def meta(self):
         return {
-            'uuid': self.uuid,
+            "uuid": self.uuid,
             #'filetype': 'bigwig',
-            'datatype': self.datatype,
-            'private': self.private,
-            'name': self.name,
+            "datatype": self.datatype,
+            "private": self.private,
+            "name": self.name,
             # 'coordSysetem': "hg19",
             # 'coordSystem2': "hg19",
         }
@@ -63,55 +70,50 @@ class Tileset:
 
 def cooler(filepath, uuid=None):
     return Tileset(
-            tileset_info=lambda: hgco.tileset_info(filepath),
-            tiles=lambda tids: hgco.tiles(filepath, tids),
-            uuid=uuid,
-            track_type='heatmap',
-            track_position='center'
-        )
+        tileset_info=lambda: hgco.tileset_info(filepath),
+        tiles=lambda tids: hgco.tiles(filepath, tids),
+        uuid=uuid,
+        track_type="heatmap",
+        track_position="center",
+    )
+
 
 def bigwig(filepath, chromsizes=None, uuid=None):
     return Tileset(
-            tileset_info=lambda: hgbi.tileset_info(filepath, chromsizes),
-            tiles=lambda tids: hgbi.tiles(filepath, tids, chromsizes=chromsizes),
-            uuid=uuid
-        )
+        tileset_info=lambda: hgbi.tileset_info(filepath, chromsizes),
+        tiles=lambda tids: hgbi.tiles(filepath, tids, chromsizes=chromsizes),
+        uuid=uuid,
+    )
+
 
 def chromsizes(filepath, uuid=None):
-    return Tileset(
-            chromsizes=lambda: hgch.get_tsv_chromsizes(filepath),
-            uuid=uuid
-        )
+    return Tileset(chromsizes=lambda: hgch.get_tsv_chromsizes(filepath), uuid=uuid)
+
 
 def mmatrix(filepath, uuid=None):
-    f = h5py.File(filepath, 'r')
+    f = h5py.File(filepath, "r")
 
     return Tileset(
         tileset_info=lambda: hgmm.tileset_info(f),
-        tiles=lambda tile_ids: hgut.tiles_wrapper_2d(tile_ids,
-                        lambda z,x,y: hgfo.format_dense_tile(
-                            hgmm.tiles(f, z, x, y)))
+        tiles=lambda tile_ids: hgut.tiles_wrapper_2d(
+            tile_ids, lambda z, x, y: hgfo.format_dense_tile(hgmm.tiles(f, z, x, y))
+        ),
     )
+
 
 import clodius.tiles.nplabels as ctnl
 import clodius.tiles.npvector as ctn
 import numpy as np
+
 
 def nplabels(labels_array, importances=None):
     if importances is None:
         importances = np.random.random(labels_array.shape)
 
     return Tileset(
-        tileset_info=lambda: ctn.tileset_info(labels_array,
-            bins_per_dimension=16),
-        tiles=lambda tids: ctnl.tiles_wrapper(labels_array,
-            tids, importances)
+        tileset_info=lambda: ctn.tileset_info(labels_array, bins_per_dimension=16),
+        tiles=lambda tids: ctnl.tiles_wrapper(labels_array, tids, importances),
     )
 
 
-by_filetype = {
-    'cooler': cooler,
-    'bigwig': bigwig,
-    'mmatrix': mmatrix,
-}
-
+by_filetype = {"cooler": cooler, "bigwig": bigwig, "mmatrix": mmatrix}

--- a/higlass/tilesets.py
+++ b/higlass/tilesets.py
@@ -44,7 +44,7 @@ class Tileset:
         if uuid is not None:
             self.uuid = uuid
         else:
-            self.uuid = slugid.nice().decode("utf-8")
+            self.uuid = slugid.nice()
 
     def tileset_info(self):
         return self.tileset_info_fn()

--- a/higlass/tilesets.py
+++ b/higlass/tilesets.py
@@ -101,19 +101,4 @@ def mmatrix(filepath, uuid=None):
     )
 
 
-import clodius.tiles.nplabels as ctnl
-import clodius.tiles.npvector as ctn
-import numpy as np
-
-
-def nplabels(labels_array, importances=None):
-    if importances is None:
-        importances = np.random.random(labels_array.shape)
-
-    return Tileset(
-        tileset_info=lambda: ctn.tileset_info(labels_array, bins_per_dimension=16),
-        tiles=lambda tids: ctnl.tiles_wrapper(labels_array, tids, importances),
-    )
-
-
 by_filetype = {"cooler": cooler, "bigwig": bigwig, "mmatrix": mmatrix}

--- a/higlass/widgets.py
+++ b/higlass/widgets.py
@@ -10,11 +10,13 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
+
+@widgets.register
 class HiGlassDisplay(widgets.DOMWidget):
     _view_name = Unicode('HiGlassDisplayView').tag(sync=True)
     _model_name = Unicode('HiGlassDisplayModel').tag(sync=True)
-    _view_module = Unicode('higlass-python').tag(sync=True)
-    _model_module = Unicode('higlass-python').tag(sync=True)
+    _view_module = Unicode('higlass-jupyter').tag(sync=True)
+    _model_module = Unicode('higlass-jupyter').tag(sync=True)
     _view_module_version = Unicode(__version__).tag(sync=True)
     _model_module_version = Unicode(__version__).tag(sync=True)
 

--- a/higlass/widgets.py
+++ b/higlass/widgets.py
@@ -1,4 +1,5 @@
 import ipywidgets as widgets
+import json
 
 from traitlets import Unicode
 from traitlets import default
@@ -6,9 +7,8 @@ from traitlets import List
 from traitlets import Dict
 from traitlets import Int
 
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions
+with open('../js/package.json', 'r') as f:
+    __version__ = json.load(f)['version']
 
 
 @widgets.register

--- a/higlass/widgets.py
+++ b/higlass/widgets.py
@@ -13,8 +13,8 @@ del get_versions
 class HiGlassDisplay(widgets.DOMWidget):
     _view_name = Unicode('HiGlassDisplayView').tag(sync=True)
     _model_name = Unicode('HiGlassDisplayModel').tag(sync=True)
-    _view_module = Unicode('jupyter-higlass').tag(sync=True)
-    _model_module = Unicode('jupyter-higlass').tag(sync=True)
+    _view_module = Unicode('higlass-python').tag(sync=True)
+    _model_module = Unicode('higlass-python').tag(sync=True)
     _view_module_version = Unicode(__version__).tag(sync=True)
     _model_module_version = Unicode(__version__).tag(sync=True)
 

--- a/js/README.md
+++ b/js/README.md
@@ -7,5 +7,5 @@ Package Install
 - [node](http://nodejs.org/)
 
 ```bash
-npm install --save jupyter-higlass
+npm install --save higlass-jupyter
 ```

--- a/js/lib/embed.js
+++ b/js/lib/embed.js
@@ -5,5 +5,5 @@
 // already be loaded by the notebook otherwise.
 
 // Export widget models and views, and the npm package version number.
-module.exports = require('./jupyter-higlass.js');
+module.exports = require('./higlass-python.js');
 module.exports['version'] = require('../package.json').version;

--- a/js/lib/embed.js
+++ b/js/lib/embed.js
@@ -5,5 +5,5 @@
 // already be loaded by the notebook otherwise.
 
 // Export widget models and views, and the npm package version number.
-module.exports = require('./higlass-python.js');
+module.exports = require('./higlass-jupyter.js');
 module.exports['version'] = require('../package.json').version;

--- a/js/lib/extension.js
+++ b/js/lib/extension.js
@@ -7,7 +7,7 @@ if (window.require) {
     window.require.config({
         map: {
             "*" : {
-                "jupyter-higlass": "nbextensions/jupyter-higlass/index",
+                "higlass-python": "nbextensions/higlass-python/index",
             }
         }
     });

--- a/js/lib/extension.js
+++ b/js/lib/extension.js
@@ -7,7 +7,7 @@ if (window.require) {
     window.require.config({
         map: {
             "*" : {
-                "higlass-python": "nbextensions/higlass-python/index",
+                "higlass-jupyter": "nbextensions/higlass-jupyter/index",
             }
         }
     });

--- a/js/lib/higlass-jupyter.js
+++ b/js/lib/higlass-jupyter.js
@@ -40,8 +40,8 @@ var HiGlassDisplayModel = widgets.DOMWidgetModel.extend({
     defaults: _.extend(_.result(this, 'widgets.DOMWidgetModel.prototype.defaults'), {
         _model_name : 'HiGlassDisplayModel',
         _view_name : 'HiGlassDisplayView',
-        _model_module : 'higlass-python',
-        _view_module : 'higlass-python',
+        _model_module : 'higlass-jupyter',
+        _view_module : 'higlass-jupyter',
         _model_module_version : '0.1.0',
         _view_module_version : '0.1.0'
     })

--- a/js/lib/higlass-python.js
+++ b/js/lib/higlass-python.js
@@ -31,7 +31,7 @@ var minimalConfig = {
         "right": [],
         "top": [],
         "bottom": []
-      } 
+      }
     }
   ]
 };
@@ -40,8 +40,8 @@ var HiGlassDisplayModel = widgets.DOMWidgetModel.extend({
     defaults: _.extend(_.result(this, 'widgets.DOMWidgetModel.prototype.defaults'), {
         _model_name : 'HiGlassDisplayModel',
         _view_name : 'HiGlassDisplayView',
-        _model_module : 'jupyter-higlass',
-        _view_module : 'jupyter-higlass',
+        _model_module : 'higlass-python',
+        _view_module : 'higlass-python',
         _model_module_version : '0.1.0',
         _view_module_version : '0.1.0'
     })
@@ -49,7 +49,7 @@ var HiGlassDisplayModel = widgets.DOMWidgetModel.extend({
 
 // Custom View. Renders the widget model.
 var HiGlassDisplayView = widgets.DOMWidgetView.extend({
-  
+
     render: function() {
         this.hgcontainer = document.createElement('div');
         // this.hgcontainer.style.margin = '1em';
@@ -90,8 +90,8 @@ var HiGlassDisplayView = widgets.DOMWidgetView.extend({
             hgOptions['bounded'] = true;
           }
         }
-        
-        
+
+
         console.log('minimalConfig:', minimalConfig);
         console.log('hgOptions:', hgOptions)
 
@@ -102,7 +102,7 @@ var HiGlassDisplayView = widgets.DOMWidgetView.extend({
             function (api) {
                 window.hgApi = api;
             }
-        );     
+        );
     }
 });
 

--- a/js/lib/index.js
+++ b/js/lib/index.js
@@ -5,8 +5,8 @@
 // Some static assets may be required by the custom widget javascript. The base
 // url for the notebook is not known at build time and is therefore computed
 // dynamically.
-__webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/jupyter-higlass/';
+__webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/higlass-python/';
 
 // Export widget models and views, and the npm package version number.
-module.exports = require('./jupyter-higlass.js');
+module.exports = require('./higlass-python.js');
 module.exports['version'] = require('../package.json').version;

--- a/js/lib/index.js
+++ b/js/lib/index.js
@@ -5,8 +5,8 @@
 // Some static assets may be required by the custom widget javascript. The base
 // url for the notebook is not known at build time and is therefore computed
 // dynamically.
-__webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/higlass-python/';
+__webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/higlass-jupyter/';
 
 // Export widget models and views, and the npm package version number.
-module.exports = require('./higlass-python.js');
+module.exports = require('./higlass-jupyter.js');
 module.exports['version'] = require('../package.json').version;

--- a/js/lib/labplugin.js
+++ b/js/lib/labplugin.js
@@ -2,11 +2,11 @@ var jupyter_higlass = require('./index');
 var base = require('@jupyter-widgets/base');
 
 module.exports = {
-  id: 'jupyter.extensions.jupyter-higlass',
+  id: 'jupyter.extensions.higlass-python',
   requires: [base.IJupyterWidgetRegistry],
   activate: function(app, widgets) {
       widgets.registerWidget({
-          name: 'jupyter-higlass',
+          name: 'higlass-python',
           version: jupyter_higlass.version,
           exports: jupyter_higlass
       });

--- a/js/lib/labplugin.js
+++ b/js/lib/labplugin.js
@@ -1,4 +1,4 @@
-var jupyter_higlass = require('./index');
+var higlassJupyter = require('./index');
 var base = require('@jupyter-widgets/base');
 
 module.exports = {
@@ -7,8 +7,8 @@ module.exports = {
   activate: function(app, widgets) {
       widgets.registerWidget({
           name: 'higlass-jupyter',
-          version: jupyter_higlass.version,
-          exports: jupyter_higlass
+          version: higlassJupyter.version,
+          exports: higlassJupyter
       });
   },
   autoStart: true

--- a/js/lib/labplugin.js
+++ b/js/lib/labplugin.js
@@ -2,11 +2,11 @@ var jupyter_higlass = require('./index');
 var base = require('@jupyter-widgets/base');
 
 module.exports = {
-  id: 'jupyter.extensions.higlass-python',
+  id: 'jupyter.extensions.higlass-jupyter',
   requires: [base.IJupyterWidgetRegistry],
   activate: function(app, widgets) {
       widgets.registerWidget({
-          name: 'higlass-python',
+          name: 'higlass-jupyter',
           version: jupyter_higlass.version,
           exports: jupyter_higlass
       });

--- a/js/package.json
+++ b/js/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1.2.3",
-    "@jupyter-widgets/jupyterlab-manager": "^0.39.0",
+    "@jupyter-widgets/jupyterlab-manager": "^0.38.1",
     "css-loader": "^0.28.7",
     "higlass": "^1.4.1",
     "higlass-multivec": "^0.2.0-alpha.3",

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "jupyter-higlass",
+  "name": "higlass-python",
   "version": "0.1.0",
-  "description": "HiGlass in your Jupyter Notebook",
+  "description": "HiGlass integration for Jupyter Notebook and Lab",
   "author": "Nezar Abdennur, Peter Kerpedjiev",
   "main": "lib/index.js",
   "repository": {
@@ -10,6 +10,8 @@
   },
   "keywords": [
     "jupyter",
+    "nootbook",
+    "lab",
     "widgets",
     "ipython",
     "ipywidgets"
@@ -28,10 +30,10 @@
     "rimraf": "^2.6.1"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.0.0",
-    "@jupyter-widgets/jupyterlab-manager": "^0.38.1",
+    "@jupyter-widgets/base": "^1.2.3",
+    "@jupyter-widgets/jupyterlab-manager": "^0.39.0",
     "css-loader": "^0.28.7",
-    "higlass": "^1.2.4",
+    "higlass": "^1.4.1",
     "higlass-multivec": "^0.2.0-alpha.3",
     "lodash": "^4.17.4",
     "react": "^16.5.1",

--- a/js/package.json
+++ b/js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "higlass-python",
+  "name": "higlass-jupyter",
   "version": "0.1.0",
   "description": "HiGlass integration for Jupyter Notebook and Lab",
   "author": "Nezar Abdennur, Peter Kerpedjiev",

--- a/notebooks/Examples.ipynb
+++ b/notebooks/Examples.ipynb
@@ -261,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -288,10 +288,10 @@
      "text": [
       "server: {'type': 'top-axis', 'options': {}}\n",
       "server: {'type': 'left-axis', 'options': {}}\n",
-      "server: {'type': 'heatmap', 'options': {'valueScaleMax': 0.5}, 'tilesetUid': 'HP_y3X4USKm-KRImOccyBw', 'server': 'http://localhost:53301/api/v1', 'height': 250}\n",
+      "server: {'type': 'heatmap', 'options': {'valueScaleMax': 0.5}, 'tilesetUid': 'Z3DfGtjVSFu6ydrE9CDOdA', 'height': 250}\n",
       "self.diskcache_directory /tmp/hgflask/dc True\n",
       "starting fuse\n",
-      "terminating: F4LkDzgxQs6fokDQ2n4e0w\n",
+      "terminating: MDtL_YxcTeKA6fluY-ZqMw\n",
       " * Serving Flask app \"higlass.server\" (lazy loading)\n",
       " * Environment: production\n",
       "   WARNING: Do not use the development server in a production environment.\n",
@@ -302,12 +302,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ad60d77adec24a1e9c33da75627a09f1",
+       "model_id": "b258888623254a45bd7b2bbe53358e02",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "HiGlassDisplay(viewconf={'editable': True, 'views': [{'uid': 'do61KY4DQ-aAg8l-o4xAuA', 'tracks': {'top': [{'ty…"
+       "HiGlassDisplay(viewconf={'editable': True, 'views': [{'uid': 'LfzDRWVLSEmHjllrbHaYnQ', 'tracks': {'top': [{'ty…"
       ]
      },
      "metadata": {},
@@ -329,9 +329,9 @@
     "    hgc.View([\n",
     "        hgc.Track(track_type='top-axis', position='top'),\n",
     "        hgc.Track(track_type='left-axis', position='left'),\n",
-    "        hgc.Track(track_type='heatmap', position='center',\n",
-    "                 tileset_uuid=ts.uuid,\n",
-    "                  server=server.api_address,\n",
+    "        hgc.Track(track_type='heatmap', \n",
+    "                  position='center',\n",
+    "                  tileset=ts,\n",
     "                  height=250,\n",
     "                 options={ 'valueScaleMax': 0.5 }),\n",
     "\n",
@@ -647,49 +647,6 @@
     "                                    zoom_sync = [view1, view2])\n",
     "display"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "self.diskcache_directory /tmp/hgflask/dc True\n",
-      "starting fuse\n",
-      "terminating: XtiJdmItQSiq-QSFbuO1iQ\n",
-      " * Serving Flask app \"higlass.server\" (lazy loading)\n",
-      " * Environment: production\n",
-      "   WARNING: Do not use the development server in a production environment.\n",
-      "   Use a production WSGI server instead.\n",
-      " * Debug mode: on\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c2cc9a137aff49d4afe168810386d6d1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HiGlassDisplay(viewconf={'editable': True, 'views': [{'uid': 'fPDhQDiuS5yiI1j3RPs92Q', 'tracks': {'top': [{'ty…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sh
 ipywidgets
 num2words
 slugid
+clodius>=0.10.4


### PR DESCRIPTION
Rename the `jupyter-higlass` JavaScript files to `higlass-jupyter` to be consistent with the package name.

Also, right now one cannot install the notebook nor the lab extension because of the name clash and because the JS package isn't actually published on npm.