### PR TITLE
Don't use -l option with umount

### DIFF
--- a/higlass/server.py
+++ b/higlass/server.py
@@ -286,7 +286,7 @@ class FuseProcess:
     def teardown(self):
         try:
             if OS_NAME == 'Darwin':
-                sh.umount("-l", self.http_directory)
+                sh.umount(self.http_directory)
             else:
                 sh.fusermount("-uz", self.http_directory)
         except Exception as ex:
@@ -294,7 +294,7 @@ class FuseProcess:
 
         try:
             if OS_NAME == 'Darwin':
-                sh.umount("-l", self.https_directory)
+                sh.umount(self.https_directory)
             else:
                 sh.fusermount("-uz", self.https_directory)
         except Exception as ex:


### PR DESCRIPTION
That option doesn't exist for umount which leads to the directory not being unmounted which leads a RunTimeError when trying to mount it.

## Description

What was changed in this pull request?

Why is it necessary?

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
