### PR TITLE
2d labelled points convenience function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+** Next release **
+
+- Convenience function for loading 2d labelled points from a dataframe.
+
 [v0.1.10](https://github.com/higlass/higlass-python/compare/v0.1.8...v0.1.10)
 
 - Synchronized Python and node package versions

--- a/higlass/client.py
+++ b/higlass/client.py
@@ -70,7 +70,8 @@ class Track:
         track_type: string
             The type of track to add (e.g. "heatmap", "line")
         position: string
-            One of 'top', 'bottom', 'center', 'left', 'right'
+            One of 'top', 'bottom', 'center', 'left', 'right'. Can be omitted
+            if the track has a default position (e.g. 'top-axis' -> 'top' )
         tileset_uuid:
             The of uuid of the tileset being displayed in this track
         height: int

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -284,17 +284,19 @@ class FuseProcess:
         proc2.join()
 
     def teardown(self):
+        print("OS_NAME:", OS_NAME)
         try:
             if OS_NAME == 'Darwin':
-                sh.umount("-l", self.http_directory)
+                sh.umount(self.http_directory)
             else:
                 sh.fusermount("-uz", self.http_directory)
         except Exception as ex:
+            print("exception:", ex)
             pass
 
         try:
             if OS_NAME == 'Darwin':
-                sh.umount("-l", self.https_directory)
+                sh.umount(self.https_directory)
             else:
                 sh.fusermount("-uz", self.https_directory)
         except Exception as ex:

--- a/higlass/tilesets.py
+++ b/higlass/tilesets.py
@@ -5,8 +5,10 @@ import clodius.tiles.mrmatrix as hgmm
 
 import clodius.tiles.utils as hgut
 import clodius.tiles.format as hgfo
+import clodius.tiles.points as hgpo
 
 import h5py
+import pandas as pd
 import slugid
 
 
@@ -99,6 +101,34 @@ def mrmatrix(filepath, uuid=None):
             tile_ids, lambda z, x, y: hgfo.format_dense_tile(hgmm.tiles(f, z, x, y))
         ),
     )
+
+def dfpoints(
+        df: pd.DataFrame,
+        x_col:str,
+        y_col:str,
+        uuid:str=None):
+    """
+    Generate a tileset that serves 2d labelled points from a pandas
+    dataframe.
+
+    Parameters:
+    -----------
+    df: The dataframe containining the data
+    x_col: The name of the column containing the x-coordinates
+    y_col: The name of the column containing the y-coordinates
+
+    Returns:
+    --------
+    A tileset capapble of serving tiles from this dataframe.
+    """
+    tsinfo = hgpo.tileset_info(df, x_col, y_col)
+
+    return Tileset(
+        tileset_info=lambda: tsinfo,
+        tiles=lambda tile_ids: hgpo.format_data(
+                    hgut.bundled_tiles_wrapper_2d(tile_ids,
+                        lambda z,x,y,width=1,height=1: hgpo.tiles(df, x_col, y_col,
+                            tsinfo, z, x, y, width, height))))
 
 import clodius.tiles.nplabels as ctnl
 import clodius.tiles.npvector as ctn

--- a/test/higlass_test.py
+++ b/test/higlass_test.py
@@ -1,7 +1,7 @@
 import higlass.client as hgc
 import json
 
-def test_viewconf_createion():
+def test_viewconf_creation():
     conf = hgc.ViewConf()
     view = conf.add_view()
 

--- a/test/tilesets_test.py
+++ b/test/tilesets_test.py
@@ -1,0 +1,19 @@
+import higlass.tilesets as hgti
+
+import pandas as pd
+
+def test_dfpoints():
+    df = pd.DataFrame({
+        'a': [1.0, 2.0, 3.0],
+        'b': [5.0, 6.0, 7.0],
+        'x': ['hi', 'there', 'you']
+    })
+
+    ts = hgti.dfpoints(
+        df, 'a', 'b', 'x'
+    )
+
+    tsinfo = ts.tileset_info()
+
+    assert len(tsinfo['min_pos']) == 2
+    assert 'max_width' in tsinfo


### PR DESCRIPTION
## Description

Added a convenience function for loading 2d labelled points from a pandas dataframe.

Why is it necessary?

To avoid the much longer method of declaring a tileset info and tile loader.

Fixes #___

## Checklist

- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [x] Updated CHANGELOG.md
