### PR TITLE
2d labelled points convenience function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+** Next release **
+
+ - Convenience function for loading 2d labelled points from a dataframe.
+ 
 [v0.1.10](https://github.com/higlass/higlass-python/compare/v0.1.8...v0.1.10)
 
 - Synchronized Python and node package versions

--- a/higlass/tilesets.py
+++ b/higlass/tilesets.py
@@ -1,16 +1,9 @@
-import clodius.tiles.bigwig as hgbi
-import clodius.tiles.chromsizes as hgch
-import clodius.tiles.cooler as hgco
-import clodius.tiles.mrmatrix as hgmm
 
 import clodius.tiles.utils as hgut
-import clodius.tiles.format as hgfo
-import clodius.tiles.points as hgpo
 
 import h5py
 import pandas as pd
 import slugid
-
 
 class Tileset:
     def __init__(
@@ -71,6 +64,8 @@ class Tileset:
 
 
 def cooler(filepath, uuid=None):
+    import clodius.tiles.cooler as hgco
+
     return Tileset(
         tileset_info=lambda: hgco.tileset_info(filepath),
         tiles=lambda tids: hgco.tiles(filepath, tids),
@@ -81,6 +76,8 @@ def cooler(filepath, uuid=None):
 
 
 def bigwig(filepath, chromsizes=None, uuid=None):
+    import clodius.tiles.bigwig as hgbi
+
     return Tileset(
         tileset_info=lambda: hgbi.tileset_info(filepath, chromsizes),
         tiles=lambda tids: hgbi.tiles(filepath, tids, chromsizes=chromsizes),
@@ -89,10 +86,15 @@ def bigwig(filepath, chromsizes=None, uuid=None):
 
 
 def chromsizes(filepath, uuid=None):
+    import clodius.tiles.chromsizes as hgch
+
     return Tileset(chromsizes=lambda: hgch.get_tsv_chromsizes(filepath), uuid=uuid)
 
 
 def mrmatrix(filepath, uuid=None):
+    import clodius.tiles.format as hgfo
+    import clodius.tiles.mrmatrix as hgmm
+
     f = h5py.File(filepath, "r")
 
     return Tileset(
@@ -135,6 +137,8 @@ def dfpoints(
     --------
     A tileset capapble of serving tiles from this dataframe.
     """
+    import clodius.tiles.points as hgpo
+
     tsinfo = hgpo.tileset_info(df, x_col, y_col)
 
     return Tileset(

--- a/higlass/tilesets.py
+++ b/higlass/tilesets.py
@@ -88,7 +88,9 @@ def bigwig(filepath, chromsizes=None, uuid=None):
 def chromsizes(filepath, uuid=None):
     import clodius.tiles.chromsizes as hgch
 
-    return Tileset(chromsizes=lambda: hgch.get_tsv_chromsizes(filepath), uuid=uuid)
+    return Tileset(
+        chromsizes=lambda: hgch.get_tsv_chromsizes(filepath),
+        uuid=uuid)
 
 
 def mrmatrix(filepath, uuid=None):
@@ -98,6 +100,7 @@ def mrmatrix(filepath, uuid=None):
     f = h5py.File(filepath, "r")
 
     return Tileset(
+        uuid=uuid,
         tileset_info=lambda: hgmm.tileset_info(f),
         tiles=lambda tile_ids: hgut.tiles_wrapper_2d(
             tile_ids, lambda z, x, y: hgfo.format_dense_tile(hgmm.tiles(f, z, x, y))
@@ -109,7 +112,9 @@ import clodius.tiles.npvector as ctn
 import numpy as np
 
 def nplabels(labels_array, importances=None):
+    """1d labels"""
     return Tileset(
+        uuid=uuid,
         tileset_info=lambda: ctn.tileset_info(labels_array,
             bins_per_dimension=16),
         tiles=lambda tids: ctnl.tiles_wrapper(labels_array,
@@ -122,18 +127,19 @@ def h5labels(filename):
 
 def dfpoints(
         df: pd.DataFrame,
-        x_col:str,
-        y_col:str,
-        uuid:str=None):
+        x_col: str,
+        y_col: str,
+        uuid: str = None):
     """
     Generate a tileset that serves 2d labelled points from a pandas
     dataframe.
-     Parameters:
+    Parameters:
     -----------
     df: The dataframe containining the data
     x_col: The name of the column containing the x-coordinates
     y_col: The name of the column containing the y-coordinates
-     Returns:
+    uuid: The uuid of this tileset
+    Returns:
     --------
     A tileset capapble of serving tiles from this dataframe.
     """
@@ -142,6 +148,7 @@ def dfpoints(
     tsinfo = hgpo.tileset_info(df, x_col, y_col)
 
     return Tileset(
+        uuid=uuid,
         tileset_info=lambda: tsinfo,
         tiles=lambda tile_ids: hgpo.format_data(
                     hgut.bundled_tiles_wrapper_2d(tile_ids,

--- a/higlass/tilesets.py
+++ b/higlass/tilesets.py
@@ -5,8 +5,10 @@ import clodius.tiles.mrmatrix as hgmm
 
 import clodius.tiles.utils as hgut
 import clodius.tiles.format as hgfo
+import clodius.tiles.points as hgpo
 
 import h5py
+import pandas as pd
 import slugid
 
 
@@ -115,6 +117,32 @@ def nplabels(labels_array, importances=None):
 def h5labels(filename):
     f = h5py.File(filename, 'r')
     return nplabels(f['labels'])
+
+def dfpoints(
+        df: pd.DataFrame,
+        x_col:str,
+        y_col:str,
+        uuid:str=None):
+    """
+    Generate a tileset that serves 2d labelled points from a pandas
+    dataframe.
+     Parameters:
+    -----------
+    df: The dataframe containining the data
+    x_col: The name of the column containing the x-coordinates
+    y_col: The name of the column containing the y-coordinates
+     Returns:
+    --------
+    A tileset capapble of serving tiles from this dataframe.
+    """
+    tsinfo = hgpo.tileset_info(df, x_col, y_col)
+
+    return Tileset(
+        tileset_info=lambda: tsinfo,
+        tiles=lambda tile_ids: hgpo.format_data(
+                    hgut.bundled_tiles_wrapper_2d(tile_ids,
+                        lambda z,x,y,width=1,height=1: hgpo.tiles(df, x_col, y_col,
+                            tsinfo, z, x, y, width, height))))
 
 by_filetype = {
     "cooler": cooler,

--- a/test/tilesets_test.py
+++ b/test/tilesets_test.py
@@ -1,0 +1,19 @@
+import higlass.tilesets as hgti
+
+import pandas as pd
+
+def test_dfpoints():
+    df = pd.DataFrame({
+        'a': [1.0, 2.0, 3.0],
+        'b': [5.0, 6.0, 7.0],
+        'x': ['hi', 'there', 'you']
+    })
+
+    ts = hgti.dfpoints(
+        df, 'a', 'b', 'x'
+    )
+
+    tsinfo = ts.tileset_info()
+
+    assert len(tsinfo['min_pos']) == 2
+    assert 'max_width' in tsinfo


### PR DESCRIPTION
## Description

Added a convenience function for loading 2d labelled points from a pandas dataframe.

Why is it necessary?

To avoid the much longer method of declaring a tileset info and tile loader.

Fixes #___

## Checklist

- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [x] Updated CHANGELOG.md
