### PR TITLE
Flekschas/jupyterlab v1 compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,9 @@ charset = utf-8
 [*.{bat,cmd,ps1}]
 end_of_line = crlf
 
+[*.js]
+indent_size = 2
+
 [Makefile]
 indent_style = tab
 indent_size = 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ** Next release **
 
+## [v0.1.13](https://github.com/higlass/higlass-python/compare/v0.1.12...v0.1.13)
+
+- Add compatibility with JupyterLab `v1` and ipywidgets `v7.5`
+- Bumped HiGlass to `v1.6`
+
 ## [v0.1.12](https://github.com/higlass/higlass-python/compare/v0.1.11...v0.1.12)
 
 - Expose dark mode in `higlass.display(dark_mode=True)`
@@ -22,7 +27,7 @@
 
 ## [v0.1.7](https://github.com/higlass/higlass-python/compare/v0.1.1...v0.1.7)
 
-- Bumped higlass version to 1.5.4
+- Bumped higlass version to `v1.5`
 - Added CombinedTrack
 - Added change_atributes and change_options functions
 

--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ Take a look at [notebooks/Examples.ipynb](notebooks/Examples.ipynb) on how to ge
    ```bash
    cd js && jupyter labextension link .
    ```
+
+### Trouble Shooting
+
+- If you are running JupyterLab `v1.x` and ipywidgets `v7.5` and the HiGlass widget is not being displayed! Then you might have an incompatible widget installed that makes all other widgets fail. Try to deinstall all other widgets to test HiGlass separately before submitting a ticket. For more information see https://github.com/jupyter-widgets/ipywidgets/issues/2483#issuecomment-508643088

--- a/js/lib/index.js
+++ b/js/lib/index.js
@@ -1,12 +1,3 @@
-// Entry point for the notebook bundle containing custom model definitions.
-//
-// Setup notebook base URL
-//
-// Some static assets may be required by the custom widget javascript. The base
-// url for the notebook is not known at build time and is therefore computed
-// dynamically.
-__webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/higlass-jupyter/';
-
 // Export widget models and views, and the npm package version number.
 module.exports = require('./higlass-jupyter.js');
 module.exports['version'] = require('../package.json').version;

--- a/js/package.json
+++ b/js/package.json
@@ -30,11 +30,11 @@
     "rimraf": "^2.6.1"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.2.3",
-    "@jupyter-widgets/jupyterlab-manager": "^0.38.1",
+    "@jupyter-widgets/base": "^1.2 || ^2",
+    "@jupyter-widgets/jupyterlab-manager": "^1.0.2",
     "css-loader": "^0.28.7",
-    "higlass": "^1.5.7",
-    "higlass-multivec": "^0.2.0",
+    "higlass": "^1.6.8",
+    "higlass-multivec": "^0.2.1",
     "lodash": "^4.17.4",
     "react": "^16.5.1",
     "react-dom": "^16.5.1",

--- a/js/package.json
+++ b/js/package.json
@@ -30,8 +30,7 @@
     "rimraf": "^2.6.1"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.2 || ^2",
-    "@jupyter-widgets/jupyterlab-manager": "^1.0.2",
+    "@jupyter-widgets/base": "^1 || ^2",
     "css-loader": "^0.28.7",
     "higlass": "^1.6.8",
     "higlass-multivec": "^0.2.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,5 @@
 numpy
 ipython
 jupyter
-jupyterlab<1.0
+jupyterlab>=1.0
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cytoolz
 flask
 flask-cors
 fusepy
-ipywidgets==7.4.2
+ipywidgets>=7.5
 multiprocess
 requests
 sh


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Update widget/base, manager, and HiGlass

> Why is it necessary?

To get the widget working with JupyterLab `v1` and ipywidgets `v7.5`

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- [x] Updated CHANGELOG.md
