### PR TITLE
Support multiple overlays and allow to set the `uid` and `type` options manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ** Next release **
 
+## [v0.2.2](https://github.com/higlass/higlass-python/compare/v0.2.1...v0.2.2)
+
+- Support multiple overlays and allow to set the `uid` and `type` options manually
+
 ## [v0.2.1](https://github.com/higlass/higlass-python/compare/v0.2.0...v0.2.1)
 
 - Fixed #30: Example working again

--- a/higlass/client.py
+++ b/higlass/client.py
@@ -217,7 +217,10 @@ class View(Component):
         for track in tracks:
             self.add_track(track)
 
-        for overlay in overlays:
+        for i, overlay in enumerate(overlays):
+            # The uids need to be unique so if no uid is available we need to
+            # define a unique uid before calling `self.add_overlay`.
+            overlay["uid"] = overlay.get("uid", "overlay-{}".format(i))
             self.add_overlay(overlay)
 
     @property
@@ -298,9 +301,9 @@ class View(Component):
         try:
             options = overlay.get("options", {})
             overlay_conf = {
-                "uid": "overlay",
-                "includes": overlay["includes"],
-                "type": "",
+                "uid": overlay.get("uid", "overlay"),
+                "includes": overlay.get("includes", []),
+                "type": overlay.get("type", ""),
                 "options": {
                     "extent": overlay.get("extent", [])
                 }


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Support multiple overlays and allow to set the `uid` and `type` options manually

> Why is it necessary?

Previously all overlays used the same uid making it impossible to have two differently styled overlays.

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [x] Updated CHANGELOG.md
