### PR TITLE
Flekschas/value scale sync, host flexibilify, no fuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ** Next release **
 
-## [v0.2.2](https://github.com/higlass/higlass-python/compare/v0.2.1...v0.2.2)
+## [v0.3.0](https://github.com/higlass/higlass-python/compare/v0.2.1...v0.3.0)
 
 - Support multiple overlays and allow to set the `uid` and `type` options manually
+- Add support for value locks via the new `value_scale_syncs` argument of `display()` and `ViewConf`
+- Allow not starting FUSE by passing `no_fuse=True` to `display()`
+- Update the HiGlass JavaScript library to `v1.7`
 
 ## [v0.2.1](https://github.com/higlass/higlass-python/compare/v0.2.0...v0.2.1)
 

--- a/higlass/client.py
+++ b/higlass/client.py
@@ -101,6 +101,21 @@ class Track(Component):
 
         self.conf.update(kwargs)
 
+        if "uid" not in self.conf:
+            self.conf["uid"] = slugid.nice()
+
+    @property
+    def uid(self):
+        return self.conf["uid"]
+
+    @property
+    def options(self):
+        return self.conf["options"]
+
+    @property
+    def type(self):
+        return self.conf["type"]
+
     def change_attributes(self, **kwargs):
         '''
         Change an attribute of this track and return a new copy.
@@ -242,12 +257,11 @@ class View(Component):
             we fall back on a default position if the track type has one.
 
         """
-        track_type = track.conf['type']
         if position is None:
             if track.position is not None:
                 position = track.position
-            elif track_type in _track_default_position:
-                position = _track_default_position[track_type]
+            elif track.type in _track_default_position:
+                position = _track_default_position[track.type]
             else:
                 raise ValueError('A track position is required.')
         self._track_position[track] = position
@@ -350,6 +364,13 @@ class ViewConf(Component):
 
     @property
     def default_view(self):
+        """Default view of the view config
+
+        The default view equals the first view if only one view exist.
+
+        Returns:
+            View -- View instance or ``None`` if more than one view exists.
+        """
         if len(self.views) == 1:
             return self.views[0]
         return None
@@ -358,11 +379,19 @@ class ViewConf(Component):
         return f"{view_uid}.{track_uid}"
 
     def _extract_view_track_uids(self, definition):
-        if isinstance(definition, collections.Mapping):
-            track_uid = definition["track"]
-            if "view" in definition:
-                view_uid = definition["view_uid"]
+        track_uid = None
+        view_uid = None
+
+        if isinstance(definition, tuple):
+            # definition is a tuple of a view and a track instance
+            view_uid = definition[0].uid
+            track_uid = definition[1].uid
+        elif isinstance(definition, Track):
+            # definition is a track instance which assumes that only one view
+            # exists
+            track_uid = definition.uid
         else:
+            # definition is a string
             uids = definition.split(".")
             if len(uids) == 2:
                 view_uid, track_uid = uids
@@ -373,19 +402,6 @@ class ViewConf(Component):
             view_uid = self.default_view.uid
 
         return view_uid, track_uid
-
-    def _add_value_sync(self, lock_group, lock_id, definitions):
-        for definition in definitions:
-            v_uid, t_uid = self._extract_view_track_uids(definition)
-            vt_uid = self._combine_view_track_uid(v_uid, t_uid)
-
-            if lock_id not in self.conf[lock_group]['locksDict']:
-                self.conf[lock_group]['locksDict'][lock_id] = {}
-            self.conf[lock_group]["locksDict"][lock_id][vt_uid] = {
-                "view": v_uid,
-                "track": t_uid,
-            }
-            self.conf[lock_group]["locksByViewUid"][vt_uid] = lock_id
 
     def _add_sync(self, lock_group, lock_id, view_uids):
         for view_uid in view_uids:
@@ -405,7 +421,24 @@ class ViewConf(Component):
         self._add_sync("locationLocks", lock_id, [v.uid for v in views_to_sync])
 
     def add_value_scale_sync(self, tracks_to_sync):
-        self._add_value_sync("valueScaleLocks", slugid.nice(), tracks_to_sync)
+        locks_map = self.conf["valueScaleLocks"]["locksByViewUid"]
+        locks_dict = self.conf["valueScaleLocks"]["locksDict"]
+        lock_id = slugid.nice()
+
+        for definition in tracks_to_sync:
+            v_uid, t_uid = self._extract_view_track_uids(definition)
+
+            if v_uid is None:
+                # If no view UID is found the definition seems to be broken
+                continue
+
+            vt_uid = self._combine_view_track_uid(v_uid, t_uid)
+
+            if lock_id not in locks_dict:
+                locks_dict[lock_id] = {}
+
+            locks_dict[lock_id][vt_uid] = { "view": v_uid, "track": t_uid }
+            locks_map[vt_uid] = lock_id
 
     def add_view(self, view):
         """

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -387,7 +387,7 @@ class Server:
             self.app.run,
             threaded=True,
             debug=True,
-            host="0.0.0.0",
+            host=self.host,
             port=self.port,
             use_reloader=False,
         )

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -323,7 +323,8 @@ class Server:
     diskcache_directory = "/tmp/hgflask/dc"
 
     def __init__(
-        self, tilesets, port=None, host="localhost", tmp_dir="/tmp/hgflask"
+        self, tilesets, port=None, host="localhost", tmp_dir="/tmp/hgflask",
+        no_fuse: bool = False
     ):
         """
         Maintain a reference to a running higlass server
@@ -345,8 +346,12 @@ class Server:
         self.port = port
         self.tmp_dir = tmp_dir
         self.file_ids = dict()
-        self.fuse_process = FuseProcess(tmp_dir)
-        self.fuse_process.setup()
+
+        if no_fuse:
+            self.fuse_process = None
+        else:
+            self.fuse_process = FuseProcess(tmp_dir)
+            self.fuse_process.setup()
 
     def start(self, log_file="/tmp/hgserver.log", log_level=logging.INFO):
         """

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -353,7 +353,7 @@ class Server:
             self.fuse_process = FuseProcess(tmp_dir)
             self.fuse_process.setup()
 
-    def start(self, log_file="/tmp/hgserver.log", log_level=logging.INFO):
+    def start(self, log_file="higlass-python.log", log_level=logging.INFO):
         """
         Start a lightweight higlass server.
 

--- a/higlass/viewer.py
+++ b/higlass/viewer.py
@@ -52,11 +52,13 @@ class HiGlassDisplay(widgets.DOMWidget):
 def display(
     views,
     location_syncs=[],
+    value_scale_syncs=[],
     zoom_syncs=[],
     host='localhost',
     server_port=None,
     dark_mode=False,
-    log_level=logging.ERROR
+    log_level=logging.ERROR,
+    no_fuse=False
 ):
     '''
     Instantiate a HiGlass display with the given views
@@ -75,7 +77,7 @@ def display(
             if track.tileset:
                 tilesets += [track.tileset]
 
-    server = Server(tilesets, host=host, port=server_port)
+    server = Server(tilesets, host=host, port=server_port, no_fuse=no_fuse)
     server.start(log_level=log_level)
 
     cloned_views = [View.from_dict(view.to_dict()) for view in views]
@@ -95,7 +97,9 @@ def display(
     viewconf = ViewConf(
         cloned_views,
         location_syncs=location_syncs,
-        zoom_syncs=zoom_syncs)
+        value_scale_syncs=value_scale_syncs,
+        zoom_syncs=zoom_syncs
+    )
 
     return (
         HiGlassDisplay(

--- a/js/package.json
+++ b/js/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@jupyter-widgets/base": "^1 || ^2",
     "css-loader": "^0.28.7",
-    "higlass": "^1.6.11",
+    "higlass": "^1.7.2",
     "higlass-multivec": "^0.2.1",
     "lodash": "^4.17.4",
     "react": "^16.5.1",


### PR DESCRIPTION
## Description

> What was changed in this pull request?

1. Added `value_scale_syncs` to `display()` and `ViewConf` to allow setting value scale locks
2. Added `no_fuse` argument to `display()` to allow not to start FUSE
3. Update hglib to `v1.7`
4. Allow setting the server host via the existing host variable

> Why is it necessary?

1. Because I want to use value scale locks
2. Because I don't always need FUSE
3. Because hglib `v1.7` rocks
4. Somehow we hard-coded `0.0.0.0` although we already had a configurable host variable.

> How?

1. Behold:

   ```python
   hans_wurst = hg.Track(uid='hans-wurst', ...)
   bock_wurst = hg.Track(uid='bock-wurst', ...)
   hg.display(
     [hg.View([hans_wurst, bock_wurst])],
     # Either by track instance, e.g.:
     valueScaleLocks=[[hans_wurst, bock_wurst]]
     # Or by the tracks' UID, e.g.:
     valueScaleLocks=[['hans-wurst', 'bock-wurst']]
   )
   ```

   If you have more than one view you have to specify the view too as a track can appear in multiple views. The syntax is very similar:

   ```python
   hans_wurst = hg.Track(uid='hans-wurst', ...)
   bock_wurst = hg.Track(uid='bock-wurst', ...)
   view1 = hg.View([hans_wurst, bock_wurst], uid='v1')
   view2 = hg.View([hans_wurst, bock_wurst], uid='v2')
   hg.display(
     [view1, view2],
     # Either by view+track instance pairs, e.g.:
     valueScaleLocks=[[(view1, hans_wurst), (view2, bock_wurst)]]
     # Or by the view-track UIDs, e.g.:
     valueScaleLocks=[['v1.hans-wurst', 'v2.bock-wurst']]
   )
   ```

2. `display(..., no_fuse=True)`

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [x] Updated CHANGELOG.md
