### PR TITLE
Added track type for view projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 -   Copied Python docs over from the higlass repo
 -   Added section on track types and multiple views to the docs
+-   Overloaded '+' operator to for combining tracks and creating CombinedTracks
+-   Added `ViewProjection` track
 
 ## [v0.3.0](https://github.com/higlass/higlass-python/compare/v0.2.1...v0.3.0)
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -75,6 +75,16 @@ Two tracks can be overlayed by using the ``+`` operator:
               tilesetUid='F2vbUeqhS86XkxuO1j2rPA')
         ], initialXDomain=[0,1e9])
 
+Another way to express this is to pass in a list of tracks
+as if it were a single track:
+
+.. code-block:: python
+
+  view=View([[Track('top-axis'),
+         Track('horizontal-bar',
+              server='//higlass.io/api/v1',
+              tilesetUid='F2vbUeqhS86XkxuO1j2rPA')
+        ]], initialXDomain=[0,1e9])
 
 Multiple Views
 --------------
@@ -141,6 +151,15 @@ it will be overlayed.
 Note that `ViewportProjection` tracks always need to be paired with other non-
 ViewportProjection tracks. Multiple ViewportProjection tracks can, however, be
 combined, as long as they are associated with regular tracks.
+
+Combined tracks can also be created by passing a list of tracks
+as if it were a track itself to a ``View``.
+
+.. code-block:: python
+
+    view2 = View([
+      [ Track(type='top-axis'), projection ]
+    ], initialXDomain=[0,2e7])
 
 Other Examples
 --------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -57,11 +57,32 @@ sometimes provide a recommended track type as well as a recommended position.
   import higlass.client as hgc
   track_type, position = hgc.datatype_to_tracktype(datatype)
 
+Combining Tracks
+----------------
+
+Tracks can be combined by overlaying them on top of each other or by performing operations with them.
+
+Overlaying tracks
+^^^^^^^^^^^^^^^^^
+
+Two tracks can be overlayed by using the ``+`` operator:
+
+.. code-block:: python
+
+  view=View([Track('top-axis') +
+         Track('horizontal-bar',
+              server='//higlass.io/api/v1',
+              tilesetUid='F2vbUeqhS86XkxuO1j2rPA')
+        ], initialXDomain=[0,1e9])
+
 
 Multiple Views
 --------------
 
-Multiple views can be instantiated much like single views. They are positioned a on grid that is 12 units wide and an arbitrary number of units high. To create two side by side views, set both to be 6 units wide and one on the right to be at x position 6:
+Multiple views can be instantiated much like single views. They are positioned
+a on grid that is 12 units wide and an arbitrary number of units high. To
+create two side by side views, set both to be 6 units wide and one on the
+right to be at x position 6:
 
 .. code-block:: python
 
@@ -99,30 +120,33 @@ views will scroll or zoom (or both) together:
 Viewport Projection
 -------------------
 
-Viewport projections can be instantiated using a decorator. To create the
-decorator, use ``projection_adder`` and pass in the View whose extent is to be
-projected. Use the returned decorator to add a viewport projection to a track.
+Viewport projections can be instantiated like other tracks. It is created with
+a reference to the view we wish to track and combined with another track where
+it will be overlayed.
 
 .. code-block:: python
 
-    from higlass.client import projection_adder
+    from higlass.client import ViewportProjection
 
     view1 = View([
         Track(type='top-axis'),
     ], initialXDomain=[0,1e7])
 
-    projection = projection_adder(view2)
+    projection = ViewportProjection(view1)
 
     view1 = View([
-        projection(Track(type='top-axis')),
+        Track(type='top-axis') + projection,
     ], initialXDomain=[0,2e7])
 
+Note that `ViewportProjection` tracks always need to be paired with other non-
+ViewportProjection tracks. Multiple ViewportProjection tracks can, however, be
+combined, as long as they are associated with regular tracks.
 
 Other Examples
 --------------
 
-The examples below demonstrate how to use the HiGlass Python API to view
-data locally in a Jupyter notebook or a browser-based HiGlass instance.
+The examples below demonstrate how to use the HiGlass Python API to view data
+locally in a Jupyter notebook or a browser-based HiGlass instance.
 
 For a fYou can find the demos from the talk at `github.com/higlass/scipy19 <https://github.com/higlass/scipy19>`_.
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -134,7 +134,7 @@ it will be overlayed.
 
     projection = ViewportProjection(view1)
 
-    view1 = View([
+    view2 = View([
         Track(type='top-axis') + projection,
     ], initialXDomain=[0,2e7])
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -96,6 +96,27 @@ views will scroll or zoom (or both) together:
     location_syncs=[[view1, view2]],
     zoom_syncs=[[view1, view2]])
 
+Viewport Projection
+-------------------
+
+Viewport projections can be instantiated using a decorator. To create the
+decorator, use ``projection_adder`` and pass in the View whose extent is to be
+projected. Use the returned decorator to add a viewport projection to a track.
+
+.. code-block:: python
+
+    from higlass.client import projection_adder
+
+    view1 = View([
+        Track(type='top-axis'),
+    ], initialXDomain=[0,1e7])
+
+    projection = projection_adder(view2)
+
+    view1 = View([
+        projection(Track(type='top-axis')),
+    ], initialXDomain=[0,2e7])
+
 
 Other Examples
 --------------

--- a/higlass/client.py
+++ b/higlass/client.py
@@ -102,6 +102,9 @@ class Track(Component):
             else:
                 raise ValueError("Track type is required.")
 
+        if not position:
+            position = _track_default_position[track_type]
+
         self.position = position
         self.tileset = tileset
 
@@ -601,21 +604,33 @@ def datatype_to_tracktype(datatype):
     return track_type, position
 
 
+class ViewportProjection(Track):
+    def __init__(self, position, fromViewUid, **kwargs):
+        if position == "center":
+            track_type = "viewport-projection-center"
+        elif position == "top" or position == "bottom":
+            track_type = "viewport-projection-horizontal"
+        elif position == "left" or position == "right":
+            track_type = "viewport-projection-vertical"
+
+        self.position = position
+        self.conf = {"type": track_type, "fromViewUid": fromViewUid}
+
+        self.conf.update(kwargs)
+
+        if "uid" not in self.conf:
+            self.conf["uid"] = slugid.nice()
+
+
 def projection_adder(view: View):
     """Return a function with adds a viewport projection."""
 
     def adder(track: Track):
-        if track.position == "center":
-            track_type = "viewport-projection-center"
-        elif track.position == "top" or track.position == "bottom":
-            track_type = "viewport-projection-horizontal"
-        elif track.position == "left" or track.position == "right":
-            track_type = "viewport-projection-vertical"
-
-        projection_track = Track(
-            track_type=track_type, position=track.position, fromViewUid=view.uid
+        projection_track = ViewportProjection(
+            position=track.position, fromViewUid=view.uid
         )
 
+        print("type1", type(projection_track))
         return CombinedTrack([track, projection_track])
 
     return adder

--- a/higlass/client.py
+++ b/higlass/client.py
@@ -301,7 +301,7 @@ class View(Component):
         self._track_position = {}
 
         for track in tracks:
-            if type(track) is list:
+            if isinstance(track, (tuple, list)):
                 new_track = CombinedTrack(track)
                 self.add_track(new_track)
             else:

--- a/higlass/client.py
+++ b/higlass/client.py
@@ -299,8 +299,13 @@ class View(Component):
             self.conf["initialYDomain"] = initialYDomain
 
         self._track_position = {}
+
         for track in tracks:
-            self.add_track(track)
+            if type(track) is list:
+                new_track = CombinedTrack(track)
+                self.add_track(new_track)
+            else:
+                self.add_track(track)
 
         for i, overlay in enumerate(overlays):
             # The uids need to be unique so if no uid is available we need to

--- a/higlass/viewer.py
+++ b/higlass/viewer.py
@@ -56,7 +56,7 @@ def display(
     Instantiate a HiGlass display with the given views
     """
     from .server import Server
-    from .client import CombinedTrack, View, ViewConf
+    from .client import CombinedTrack, View, ViewConf, ViewportProjection
 
     tilesets = []
 
@@ -64,7 +64,7 @@ def display(
         for track in view.tracks:
             if hasattr(track, "tracks"):
                 for track1 in track.tracks:
-                    if track1.tileset:
+                    if not isinstance(track1, ViewportProjection) and track1.tileset:
                         tilesets += [track1.tileset]
 
             if track.tileset:
@@ -79,8 +79,14 @@ def display(
         for track in view.tracks:
             if isinstance(track, CombinedTrack):
                 for track1 in track.tracks:
-                    if "server" not in track1.conf or track1.conf["server"] is None:
+                    if "fromViewUid" in track1.conf:
+                        # this is a viewport projection and doesn't have
+                        # a server
+                        pass
+                    elif "server" not in track1.conf or track1.conf["server"] is None:
                         track1.conf["server"] = server.api_address
+            elif "fromViewUid" in track.conf:
+                pass
             else:
                 if "server" not in track.conf or track.conf["server"] is None:
                     track.conf["server"] = server.api_address

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -1,20 +1,35 @@
-from higlass.client import Track, View, projection_adder
+from higlass.client import Track, View, ViewportProjection
 import higlass
 
 
+def test_add_tracks():
+    track1 = Track("top-axis")
+    track2 = Track("top-axis")
+
+    track3 = track1 + track2
+
+    assert track1 in track3.tracks
+
+    track4 = Track("top-axis")
+    track5 = track3 + track4
+
+    assert track1 in track5.tracks
+    assert track4 in track5.tracks
+
+
 def test_viewport_projection():
-    view1 = View([Track("top-axis")])
+    track1 = Track("top-axis")
+    view1 = View([track1])
 
-    adder = projection_adder(view1)
+    vp = ViewportProjection(view1)
 
-    view2 = View([adder(Track("top-axis"))])
+    track2 = Track("top-axis")
+    track3 = track2 + vp
 
-    (display, server, viewconf) = higlass.display([view1, view2])
+    assert vp.conf["type"] == "viewport-projection"
+    assert track3.tracks[1].conf["type"] == "viewport-projection-horizontal"
 
-    print(viewconf.to_dict()["views"][1]["tracks"]["top"][0])
-    assert (
-        "server"
-        not in viewconf.to_dict()["views"][1]["tracks"]["top"][0]["contents"][1]
-    )
+    track4 = Track("heatmap")
+    track5 = track4 + vp
 
-    server.stop()
+    assert track5.tracks[1].conf["type"] == "viewport-projection-center"

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -1,0 +1,20 @@
+from higlass.client import Track, View, projection_adder
+import higlass
+
+
+def test_viewport_projection():
+    view1 = View([Track("top-axis")])
+
+    adder = projection_adder(view1)
+
+    view2 = View([adder(Track("top-axis"))])
+
+    (display, server, viewconf) = higlass.display([view1, view2])
+
+    print(viewconf.to_dict()["views"][1]["tracks"]["top"][0])
+    assert (
+        "server"
+        not in viewconf.to_dict()["views"][1]["tracks"]["top"][0]["contents"][1]
+    )
+
+    server.stop()

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -14,8 +14,7 @@ def test_add_tracks():
     track4 = Track("top-axis")
     track5 = track3 + track4
 
-    assert track1 in track5.tracks
-    assert track4 in track5.tracks
+    assert len(track5.tracks) == 3
 
 
 def test_combined_track_from_track_list():

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -3,6 +3,7 @@ import higlass
 
 
 def test_add_tracks():
+    """Test combining tracks using the '+' operator."""
     track1 = Track("top-axis")
     track2 = Track("top-axis")
 
@@ -17,7 +18,25 @@ def test_add_tracks():
     assert track4 in track5.tracks
 
 
+def test_combined_track_from_track_list():
+    """Test creating a CombinedTrack by providing a list
+    of tracks when creating a View."""
+    track1 = Track("top-axis")
+    track2 = Track("horizontal-line")
+
+    view = View([[track1, track2]])
+
+    view_dict = view.to_dict()
+    print("view_dict:", view_dict)
+
+    combined_track = view_dict["tracks"]["top"][0]
+
+    assert combined_track["type"] == "combined"
+    assert combined_track["contents"][0]["type"] == "top-axis"
+
+
 def test_viewport_projection():
+    """Test creating a ViewportProjection track."""
     track1 = Track("top-axis")
     view1 = View([track1])
 


### PR DESCRIPTION
## Description

What was changed in this pull request?

This PR introduces a new track type for view projections. See the attached change in the docs for an example of how it's used.

This PR also overloads the `+` operator for tracks to create CombinedTracks. So to overlay two tracks, one simple needs to do `track1 + track2`. This same operation can be performed by passing in a list of lists to the View constructor: `View([[track1, track2], track3])`.

Why is it necessary?

The previous method of creating view projections was too cumbersome.

Fixes #___

## Checklist

- [x] Unit tests added or updated
- [x] Documentation added or updated
- [x] Updated CHANGELOG.md
- [x] Ran `black` on the root directory
