### PR TITLE
Pass in a view as a list of tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 -   Added section on track types and multiple views to the docs
 -   Overloaded '+' operator to for combining tracks and creating CombinedTracks
 -   Added `ViewProjection` track
+-   Created simplified view creation API
 
 ## [v0.3.0](https://github.com/higlass/higlass-python/compare/v0.2.1...v0.3.0)
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -34,6 +34,24 @@ Uninstalling
 
     jupyter nbextension uninstall --py --sys-prefix higlass
 
+Simplest Use Case
+------------------
+
+The simplest way to instantiate a HiGlass instance to create a display object with one view:
+
+.. code-block:: python
+
+  import higlass
+  from higlass.client import Track
+
+  display, server, viewconf = higlass.display([View([Track('top-axis')])])
+  display
+
+If brevity is of importance, the constructor for ``View`` can be omitted and a
+view will automatically be created from the list of Tracks:
+``higlass.display([[Track('top-axis')]])``. This, however, precludes the use
+of parameters with the view or for linking views using syncs.
+
 View extent
 -----------
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -50,7 +50,8 @@ The simplest way to instantiate a HiGlass instance to create a display object wi
 If brevity is of importance, the constructor for ``View`` can be omitted and a
 view will automatically be created from the list of Tracks:
 ``higlass.display([[Track('top-axis')]])``. This, however, precludes the use
-of parameters with the view or for linking views using syncs.
+of parameters with the view or for linking views using syncs. It also always
+uses the `default position <https://github.com/higlass/higlass-python/blob/70d36d18eb8ef9e207640de5e7bc478c43fdc8de/higlass/client.py#L23>`_ for a given track type.
 
 View extent
 -----------

--- a/higlass/viewer.py
+++ b/higlass/viewer.py
@@ -53,12 +53,43 @@ def display(
     no_fuse=False,
 ):
     """
-    Instantiate a HiGlass display with the given views
+    Instantiate a HiGlass display with the given views.
+
+    Args:
+        views: A list of views to display. If the items in the list are
+            lists themselves, then automatically create views out of them.
+        location_syncs: A list of lists, each containing a list of views which
+            will scroll together.
+        zoom_syncs: A list of lists, each containing a list of views that
+            will zoom together.
+        host: The host on which the internal higlass server will be running on.
+        server_port: The port on which the internal higlass server will be running on.
+        dark_mode: Whether to use dark mode or not.
+        log_level: Level of logging to perform.
+        no_fuse: Don't mount the fuse filesystem. Useful if not loading any data
+            over http or https.
+
+    Returns:
+        (display: HiGlassDisplay, server: higlass.server.Server, higlass.client.viewconf) tuple
+        Display is an object used to create
+        a HiGlass viewer within a Jupyter notebook. The server object encapsulates
+        a Flask instance of a higlass server and the viewconf is a Python object
+        containing the viewconf describing the higlass dashboard.
     """
     from .server import Server
     from .client import CombinedTrack, View, ViewConf, ViewportProjection
 
     tilesets = []
+
+    # views can also be passed in as lists of tracks
+    new_views = []
+    for view in views:
+        if isinstance(view, (tuple, list)):
+            # view is a list of tracks
+            new_views.append(View(view))
+        else:
+            new_views.append(view)
+    views = new_views
 
     for view in views:
         for track in view.tracks:

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -26,8 +26,6 @@ def test_combined_track_from_track_list():
     view = View([[track1, track2]])
 
     view_dict = view.to_dict()
-    print("view_dict:", view_dict)
-
     combined_track = view_dict["tracks"]["top"][0]
 
     assert combined_track["type"] == "combined"

--- a/test/viewer_test.py
+++ b/test/viewer_test.py
@@ -3,21 +3,18 @@ from unittest.mock import patch
 from higlass.client import View, Track
 from higlass.viewer import display
 
+
 def test_create_display():
     """Test to make sure we can create a display."""
-    with patch('higlass.server.Server') as _:
-        (_, _, viewconf) = display(
-            [View([Track('top-axis')])]
-        )
+    with patch("higlass.server.Server") as _:
+        (_, _, viewconf) = display([View([Track("top-axis")])])
 
         vc_dict = viewconf.to_dict()
 
-        assert len(vc_dict['views']) == 1
+        assert len(vc_dict["views"]) == 1
 
-        (_, _, viewconf) = display(
-            [[Track('top-axis')]]
-        )
+        (_, _, viewconf) = display([[Track("top-axis")]])
 
         vc_dict = viewconf.to_dict()
 
-        assert len(vc_dict['views']) == 1
+        assert len(vc_dict["views"]) == 1

--- a/test/viewer_test.py
+++ b/test/viewer_test.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+from higlass.client import View, Track
+from higlass.viewer import display
+
+def test_create_display():
+    """Test to make sure we can create a display."""
+    with patch('higlass.server.Server') as _:
+        (_, _, viewconf) = display(
+            [View([Track('top-axis')])]
+        )
+
+        vc_dict = viewconf.to_dict()
+
+        assert len(vc_dict['views']) == 1
+
+        (_, _, viewconf) = display(
+            [[Track('top-axis')]]
+        )
+
+        vc_dict = viewconf.to_dict()
+
+        assert len(vc_dict['views']) == 1


### PR DESCRIPTION
## Description

What was changed in this pull request?

This PR provides a simplified way of declaring views in a display by simply passing in a list of tracks.

```
higlass.display([View([Track('top-axis')])])
```

can now be written as:

```
higlass.display([[Track('top-axis')]])
```

Why is it necessary?

Save some typing.

Fixes #___

## Checklist

- [x] Unit tests added or updated
- [x] Documentation added or updated
- [x] Updated CHANGELOG.md
- [x] Ran `black` on the root directory
