### PR TITLE
Infer filetype and datatype from filename

### DIFF
--- a/higlass/utils.py
+++ b/higlass/utils.py
@@ -90,7 +90,6 @@ def fill_filetype_and_datatype(filename, filetype=None, datatype=None):
     if filetype is None:
         # no filetype provided, try a few common filetypes
         filetype = infer_filetype(filename)
-        print("Inferred filetype:", filetype)
 
         if filetype is None:
             recommended_filetype = recommend_filetype(filename)
@@ -110,7 +109,6 @@ def fill_filetype_and_datatype(filename, filetype=None, datatype=None):
 
     if datatype is None:
         datatype = infer_datatype(filetype)
-        print("Inferred datatype:", datatype)
 
         if datatype is None:
             recommended_datatype = recommend_datatype(filetype)

--- a/higlass/utils.py
+++ b/higlass/utils.py
@@ -40,7 +40,7 @@ def recommend_datatype(filetype):
         return "bedlike"
 
 
-filetypes = {
+FILETYPES = {
     "cooler": {
         "description": "multi-resolution cooler file",
         "extensions": [".mcool"],
@@ -72,7 +72,7 @@ filetypes = {
 def infer_filetype(filename):
     _, ext = op.splitext(filename)
 
-    for filetype, meta in filetypes.items():
+    for filetype, meta in FILETYPES.items():
         if ext.lower() in meta["extensions"]:
             return filetype
 
@@ -80,8 +80,8 @@ def infer_filetype(filename):
 
 
 def infer_datatype(filetype):
-    if filetype in filetypes:
-        return filetypes[filetype]["datatypes"][0]
+    if filetype in FILETYPES:
+        return FILETYPES[filetype]["datatypes"][0]
 
     return None
 
@@ -139,4 +139,4 @@ def fill_filetype_and_datatype(filename, filetype=None, datatype=None):
                     )
                 )
 
-    return (filetype, datatype)
+    return filetype, datatype

--- a/higlass/utils.py
+++ b/higlass/utils.py
@@ -40,34 +40,50 @@ def recommend_datatype(filetype):
         return "bedlike"
 
 
+filetypes = {
+    "cooler": {
+        "description": "multi-resolution cooler file",
+        "extensions": [".mcool"],
+        "datatypes": ["matrix"],
+    },
+    "bigwig": {
+        "description": "Genomics focused multi-resolution vector file",
+        "extensions": [".bw", ".bigwig"],
+        "datatypes": ["vector"],
+    },
+    "beddb": {
+        "description": "SQLite-based multi-resolution annotation file",
+        "extensions": [".beddb", ".multires.db"],
+        "datatypes": ["bedlike", "gene-annotations"],
+    },
+    "hitile": {
+        "description": "Multi-resolution vector file",
+        "extensions": [".hitile"],
+        "datatypes": ["vector"],
+    },
+    "time-interval-json": {
+        "description": "Time interval notation",
+        "extensions": [".htime"],
+        "datatypes": ["time-interval"],
+    },
+}
+
+
 def infer_filetype(filename):
     _, ext = op.splitext(filename)
 
-    if ext.lower() == ".bw" or ext.lower() == ".bigwig":
-        return "bigwig"
-    elif ext.lower() == ".mcool" or ext.lower() == ".cool":
-        return "cooler"
-    elif ext.lower() == ".htime":
-        return "time-interval-json"
-    elif ext.lower() == ".hitile":
-        return "hitile"
-    elif ext.lower() == ".beddb":
-        return "beddb"
+    for filetype, meta in filetypes.items():
+        if ext.lower() in meta["extensions"]:
+            return filetype
 
     return None
 
 
 def infer_datatype(filetype):
-    if filetype == "cooler":
-        return "matrix"
-    if filetype == "bigwig":
-        return "vector"
-    if filetype == "time-interval-json":
-        return "time-interval"
-    if filetype == "hitile":
-        return "vector"
-    if filetype == "beddb":
-        return "bedlike"
+    if filetype in filetypes:
+        return filetypes[filetype]["datatypes"][0]
+
+    return None
 
 
 def fill_filetype_and_datatype(filename, filetype=None, datatype=None):

--- a/higlass/utils.py
+++ b/higlass/utils.py
@@ -1,4 +1,6 @@
 import matplotlib.pyplot as plt
+import os.path as op
+import sys
 
 
 def hg_cmap(cmap_name, resolution=256, reverse=False):
@@ -23,3 +25,104 @@ def hg_cmap(cmap_name, resolution=256, reverse=False):
         return hg_cmap[::-1]
 
     return hg_cmap
+
+
+def recommend_filetype(filename):
+    ext = op.splitext(filename)
+    if op.splitext(filename)[1] == ".bed":
+        return "bedfile"
+    if op.splitext(filename)[1] == ".bedpe":
+        return "bedpe"
+
+
+def recommend_datatype(filetype):
+    if filetype == "bedfile":
+        return "bedlike"
+
+
+def infer_filetype(filename):
+    _, ext = op.splitext(filename)
+
+    if ext.lower() == ".bw" or ext.lower() == ".bigwig":
+        return "bigwig"
+    elif ext.lower() == ".mcool" or ext.lower() == ".cool":
+        return "cooler"
+    elif ext.lower() == ".htime":
+        return "time-interval-json"
+    elif ext.lower() == ".hitile":
+        return "hitile"
+    elif ext.lower() == ".beddb":
+        return "beddb"
+
+    return None
+
+
+def infer_datatype(filetype):
+    if filetype == "cooler":
+        return "matrix"
+    if filetype == "bigwig":
+        return "vector"
+    if filetype == "time-interval-json":
+        return "time-interval"
+    if filetype == "hitile":
+        return "vector"
+    if filetype == "beddb":
+        return "bedlike"
+
+
+def fill_filetype_and_datatype(filename, filetype=None, datatype=None):
+    """
+    If no filetype or datatype are provided, add them
+    based on the given filename.
+    Parameters:
+    ----------
+    filename: str
+        The name of the file
+    filetype: str
+        The type of the file (can be None)
+    datatype: str
+        The datatype for the data in the file (can be None)
+    Returns:
+    --------
+    (filetype, datatype): (str, str)
+        Filled in filetype and datatype based on the given filename
+    """
+    if filetype is None:
+        # no filetype provided, try a few common filetypes
+        filetype = infer_filetype(filename)
+        print("Inferred filetype:", filetype)
+
+        if filetype is None:
+            recommended_filetype = recommend_filetype(filename)
+
+            print(
+                "Unknown filetype, please specify using the --filetype option",
+                file=sys.stderr,
+            )
+            if recommended_filetype is not None:
+                print(
+                    "Based on the filename, you may want to try the filetype: {}".format(
+                        recommended_filetype
+                    )
+                )
+
+            return (None, None)
+
+    if datatype is None:
+        datatype = infer_datatype(filetype)
+        print("Inferred datatype:", datatype)
+
+        if datatype is None:
+            recommended_datatype = recommend_datatype(filetype)
+            print(
+                "Unknown datatype, please specify using the --datatype option",
+                file=sys.stderr,
+            )
+            if recommended_datatype is not None:
+                print(
+                    "Based on the filetype, you may want to try the datatype: {}".format(
+                        recommended_datatype
+                    )
+                )
+
+    return (filetype, datatype)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ flask
 flask-cors
 fusepy
 ipywidgets>=7.5
+matplotlib
 multiprocess
 requests
 sh

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -1,0 +1,8 @@
+from higlass.utils import fill_filetype_and_datatype
+
+
+def test_fill_filetype_and_datatype():
+    filetype, datatype = fill_filetype_and_datatype("myfile.mcool")
+
+    assert filetype == "cooler"
+    assert datatype == "matrix"

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -6,3 +6,8 @@ def test_fill_filetype_and_datatype():
 
     assert filetype == "cooler"
     assert datatype == "matrix"
+
+    filetype, datatype = fill_filetype_and_datatype("myfile.xyz")
+
+    assert not filetype
+    assert not datatype


### PR DESCRIPTION
## Description

What was changed in this pull request?

Added functions to infer the filetype and datatype of a dataset from its filename. Lifted directly from https://github.com/higlass/higlass-manage/blob/687b40f56fca3c392f401b294828a8c0f9f66c5c/higlass_manage/common.py#L44 and added a test.

Once this is merged, `higlass-manage` can be updated to use the functions here.

Why is it necessary?

To factor out this functionality so that it can be maintained in a common place.

Fixes #___

## Checklist

- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
- [x] Ran `black` on the root directory
