### PR TITLE
Auth tokens for viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Overloaded the '/' operator to create divided tracks
 -   Added support using matplotlib colormaps
 -   Created simplified view creation API
+-   Add auth_token parameter to higlass.display
 
 ## [v0.3.0](https://github.com/higlass/higlass-python/compare/v0.2.1...v0.3.0)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "HiGlass"
-copyright = "2017-2019 HiGlass Authors"
+copyright = "2017-2020 HiGlass Authors"
 author = "HiGlass Authors"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -248,6 +248,19 @@ Not that this function can only be used within a Jupyter notebook
 and works asynchronously so the saved screenshot will not nessarily
 be complete immediately after the function finishes executing
 
+Authorization
+-------------
+
+If loading tiles from a secured server, the ``auth_token`` parameter takes the
+string that will be used as the Authorization header on all tile requests sent
+out by HiGlass:
+
+.. code-block:: python
+
+  (d,s,v) = higlass.display(views, auth_token='JWT DEADBEEF')
+
+
+
 Other Examples
 --------------
 

--- a/higlass/client.py
+++ b/higlass/client.py
@@ -729,7 +729,7 @@ def position_to_viewport_projection_type(position):
 
 
 class ViewportProjection(Track):
-    def __init__(self, view, position=None):
+    def __init__(self, view, position=None, options=None):
         self.position = position
         track_type = position_to_viewport_projection_type(position)
         self.conf = {"type": track_type, "fromViewUid": view.uid}
@@ -738,6 +738,11 @@ class ViewportProjection(Track):
         if "uid" not in self.conf:
             self.conf["uid"] = slugid.nice()
 
+        if options is None:
+            self.conf["options"] = {}
+        else:
+            self.conf["options"] = deepcopy(options)
+
     def copy(self):
         """Copy this track."""
-        return ViewportProjection(self.view, self.position)
+        return ViewportProjection(self.view, self.position, self.conf["options"])

--- a/higlass/viewer.py
+++ b/higlass/viewer.py
@@ -133,7 +133,7 @@ def display(
         containing the viewconf describing the higlass dashboard.
     """
     from .server import Server
-    from .client import CombinedTrack, View, ViewConf, ViewportProjection
+    from .client import CombinedTrack, DividedTrack, View, ViewConf, ViewportProjection
 
     tilesets = []
 
@@ -174,6 +174,10 @@ def display(
                         track1.conf["server"] = server.api_address
             elif "fromViewUid" in track.conf:
                 pass
+            elif "data" in track.conf:
+                # probably a divided track with a custom
+                # data fetcher
+                pass
             else:
                 if "server" not in track.conf or track.conf["server"] is None:
                     track.conf["server"] = server.api_address
@@ -185,11 +189,15 @@ def display(
         zoom_syncs=zoom_syncs,
     )
 
+    extra_args = {}
+    if auth_token:
+        extra_args["auth_token"] = auth_token
+
     return (
         HiGlassDisplay(
             viewconf=viewconf.to_dict(),
             hg_options={"theme": "dark" if dark_mode else "light",},
-            auth_token=auth_token,
+            **extra_args
         ),
         server,
         viewconf,

--- a/higlass/viewer.py
+++ b/higlass/viewer.py
@@ -106,6 +106,7 @@ def display(
     dark_mode=False,
     log_level=logging.ERROR,
     no_fuse=False,
+    auth_token=None,
 ):
     """
     Instantiate a HiGlass display with the given views.
@@ -187,7 +188,8 @@ def display(
     return (
         HiGlassDisplay(
             viewconf=viewconf.to_dict(),
-            hg_options={"theme": "dark" if dark_mode else "light"},
+            hg_options={"theme": "dark" if dark_mode else "light",},
+            auth_token=auth_token,
         ),
         server,
         viewconf,


### PR DESCRIPTION
## Description

What was changed in this pull request?

- Add the ability to pass in an auth token to be used with the higlass viewer
- Fix some issues with the ViewportProjection and Divided tracks

Why is it necessary?

Using HiGlass with secured data sources requires the ability to pass in authorization information.

Fixes #___

## Checklist

- [x] Unit tests added or updated
- [x] Documentation added or updated
- [x] Updated CHANGELOG.md
- [x] Ran `black` on the root directory
