### PR TITLE
Log to StringIO by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
         - pip install -r requirements-dev.txt
         - python setup.py install
       script:
-        - mkdir data && ./test/get_test_data.sh
+        - ./test/get_test_data.sh
         - pytest
       before_deploy:
         - pip install --user -r docs/requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ** Next release **
 
+-   Removed default log file creation. Servers now log to in-memory stream by default.
 -   Copied Python docs over from the higlass repo
 -   Added `save_as_png` function
 -   Added section on track types and multiple views to the docs

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -216,6 +216,7 @@ rather than the entire dataset:
 They can also be created using a constructor:
 
 .. code-block:: python
+
     from higlass.client import DividedTrack
 
     t3 = DividedTrack(t1, t2)
@@ -613,3 +614,27 @@ requests:
 
 
 In this case, we expect *tile_data* to simply return a matrix of values.
+
+
+Troubleshooting
+---------------
+
+Accessing the server log
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+A local server writes its log records to an in-memory `StringIO <https://docs.python.org/3/library/io.html#io.StringIO>`_ buffer. The server's name can be used to access its logger.
+
+.. code-block:: python
+
+    import logging
+
+    logger = logging.getLogger(server.name)
+    logger.info('Hi!')
+
+    # convert the stream into a string
+    print(server.log.getvalue())
+
+    # write the log to a file
+    with open('higlass-server.log', 'wt') as f:
+        f.write(server.log.getvalue())
+

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -1,10 +1,13 @@
 from functools import partial
+from io import StringIO
 import multiprocess as mp
 import cytoolz as toolz
 import os.path as op
 import platform
 import logging
+import logging.handlers
 import socket
+import tempfile
 import json
 import time
 import os
@@ -24,17 +27,20 @@ import sh
 __all__ = ["Server"]
 
 OS_NAME = platform.system()
+OS_TEMPDIR = tempfile.gettempdir()
 
-# Disable annoying flask logs
+
+# Disable annoying logs from werkzeug server
 log = logging.getLogger("werkzeug")
 log.setLevel(logging.ERROR)
 log.disabled = True
+
 # The following line is also needed to turn off all debug logs
 os.environ["WERKZEUG_RUN_MAIN"] = "true"
 
 
-def create_app(tilesets, name, log_file, log_level, file_ids, fuse=None):
-    app = Flask(__name__)
+def create_app(name, tilesets, fuse=None):
+    app = Flask(name)
     app.logger.disabled = True
     CORS(app)
 
@@ -54,6 +60,7 @@ def create_app(tilesets, name, log_file, log_level, file_ids, fuse=None):
                 jsonify({"error": "Unknown filetype: {}".format(js["filetype"])}),
                 400,
             )
+
         if fuse is None:
             return jsonify({"error": "httpfs is not available."})
 
@@ -61,10 +68,24 @@ def create_app(tilesets, name, log_file, log_level, file_ids, fuse=None):
         if key in remote_tilesets:
             ts = remote_tilesets[key]
         else:
+            mounted_url = fuse.get_filepath(js["fileUrl"])
             factory = by_filetype[js["filetype"]]
-            ts = factory(fuse.get_filepath(js["fileUrl"]))
+            ts = factory(mounted_url)
             remote_tilesets[key] = ts
+
         return jsonify({"uid": ts.uuid})
+
+    @app.route("/api/v1/available-chrom-sizes/", methods=["GET"])
+    def available_chrom_sizes():
+        """
+        Get the list of available chromosome size lists. No query parameters.
+
+        """
+        results = []
+        for ts in tilesets:
+            if ts.datatype == "chromsizes":
+                results.append(ts.meta)
+        return jsonify({"count": count, "results": results})
 
     @app.route("/api/v1/chrom-sizes/", methods=["GET"])
     def chrom_sizes():
@@ -177,13 +198,6 @@ def create_app(tilesets, name, log_file, log_level, file_ids, fuse=None):
             tiles.extend(ts.tiles(tids))
         data = {tid: tval for tid, tval in tiles}
         return jsonify(data)
-
-    if log_file is not None:
-        logging.basicConfig(
-            level=log_level,
-            filename=log_file,
-            format="[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
-        )
 
     return app
 
@@ -302,83 +316,101 @@ class Server:
     # Keep track of the server processes that have been started.
     # So that when someone says 'start', the old ones are terminated
     processes = {}
-    diskcache_directory = "/tmp/hgflask/dc"
 
     def __init__(
         self,
         tilesets,
-        port=None,
         host="localhost",
-        tmp_dir="/tmp/hgflask",
-        no_fuse: bool = False,
+        port=None,
+        name=None,
+        fuse=True,
+        tmp_dir=OS_TEMPDIR,
     ):
         """
         Maintain a reference to a running higlass server
 
         Parameters
         ----------
-        port: int
-            The port that this server will run on
-        tilesets: []
+        tilesets : list
             A list of tilesets to serve (see higlass.tilesets)
-        host: string
-            The host this server is running on.  Usually just localhost
-        tmp_dir: string
-            A temporary directory into which to mount the http and https files
+        host : str, optional
+            The host this server is running on. Usually just localhost.
+        port : int, optional
+            The port that this server will run on.
+        name : str, optional
+            A name for the Flask app being served
+        fuse : bool, optional
+            Whether to mount http(s) resources using FUSE.
+        tmp_dir : string, optional
+            A temporary directory for FUSE to mount the http(s) files and
+            for caching.
 
         """
+        self.name = name or __name__.split(".")[0] + slugid.nice()[:8]
         self.tilesets = tilesets
         self.host = host
         self.port = port
-        self.tmp_dir = tmp_dir
-        self.file_ids = dict()
-
-        if no_fuse:
-            self.fuse_process = None
-        else:
+        if fuse:
             self.fuse_process = FuseProcess(tmp_dir)
             self.fuse_process.setup()
+        else:
+            self.fuse_process = None
 
-    def start(self, log_file=None, log_level=logging.INFO):
+    def start(self, debug=False, log_level=logging.INFO, log_file=None, **kwargs):
         """
         Start a lightweight higlass server.
 
         Parameters
         ----------
-        log_file: string
-            Where to place diagnostic log files
+        debug: bool
+            Run the server in debug mode. Default is False.
         log_level: logging.*
             What level to log at
+        log_file: str, optional
+            Where to write diagnostic log files. Default is to use a
+            StringIO stream in memory.
+        kwargs :
+            Additional options to pass to app.run
+
         """
         for puid in list(self.processes.keys()):
             self.processes[puid].terminate()
             del self.processes[puid]
 
-        self.app = create_app(
-            self.tilesets,
-            __name__,
-            log_file=log_file,
-            log_level=log_level,
-            file_ids=self.file_ids,
-            fuse=self.fuse_process,
-        )
+        self.app = create_app(__name__, self.tilesets, fuse=self.fuse_process)
+
+        if log_file:
+            self.log = None
+            handler = logging.handlers.RotatingFileHandler(
+                log_file, maxBytes=100000, backupCount=1
+            )
+            handler.setLevel(log_level)
+        else:
+            self.log = StringIO()
+            handler = logging.StreamHandler(self.log)
+            handler.setLevel(log_level)
+        self.app.logger.addHandler(handler)
+
+        if self.port is None:
+            self.port = get_open_port()
 
         # we're going to assign a uuid to each server process so that if
         # anything goes wrong, the variable referencing the process doesn't get
         # lost
         uuid = slugid.nice()
-        if self.port is None:
-            self.port = get_open_port()
+
         target = partial(
             self.app.run,
-            threaded=True,
-            debug=True,
+            debug=debug,
             host=self.host,
             port=self.port,
+            threaded=True,
             use_reloader=False,
+            **kwargs
         )
         self.processes[uuid] = mp.Process(target=target)
         self.processes[uuid].start()
+
         self.connected = False
         while not self.connected:
             try:
@@ -393,8 +425,8 @@ class Server:
         """
         Stop this server so that the calling process can exit
         """
-        # unsetup_fuse()
-        self.fuse_process.teardown()
+        if self.fuse_process is not None:
+            self.fuse_process.teardown()
         for uuid in self.processes:
             self.processes[uuid].terminate()
 

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -311,8 +311,29 @@ class FuseProcess:
 class Server:
     """
     A lightweight HiGlass server.
-    """
 
+    Parameters
+    ----------
+    tilesets : list
+        A list of tilesets to serve (see higlass.tilesets)
+    host : str, optional
+        The host this server is running on. Usually just localhost.
+    port : int, optional
+        The port that this server will run on.
+    name : str, optional
+        A name for the Flask app being served
+    fuse : bool, optional
+        Whether to mount http(s) resources using FUSE.
+    tmp_dir : string, optional
+        A temporary directory for FUSE to mount the http(s) files and
+        for caching.
+    log_level: logging.*
+        What level to log at
+    log_file: str, optional
+        Where to write diagnostic log files. Default is to use a
+        StringIO stream in memory.
+
+    """
     # Keep track of the server processes that have been started.
     # So that when someone says 'start', the old ones are terminated
     processes = {}
@@ -328,31 +349,6 @@ class Server:
         log_level=logging.INFO,
         log_file=None,
     ):
-        """
-        Maintain a reference to a running higlass server
-
-        Parameters
-        ----------
-        tilesets : list
-            A list of tilesets to serve (see higlass.tilesets)
-        host : str, optional
-            The host this server is running on. Usually just localhost.
-        port : int, optional
-            The port that this server will run on.
-        name : str, optional
-            A name for the Flask app being served
-        fuse : bool, optional
-            Whether to mount http(s) resources using FUSE.
-        tmp_dir : string, optional
-            A temporary directory for FUSE to mount the http(s) files and
-            for caching.
-        log_level: logging.*
-            What level to log at
-        log_file: str, optional
-            Where to write diagnostic log files. Default is to use a
-            StringIO stream in memory.
-
-        """
         self.name = name or __name__.split(".")[0] + '-' + slugid.nice()[:8]
         self.tilesets = tilesets
         self.host = host

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -346,7 +346,7 @@ class Server:
             for caching.
 
         """
-        self.name = name or __name__.split(".")[0] + slugid.nice()[:8]
+        self.name = name or __name__.split(".")[0] + '-' + slugid.nice()[:8]
         self.tilesets = tilesets
         self.host = host
         self.port = port
@@ -377,7 +377,7 @@ class Server:
             self.processes[puid].terminate()
             del self.processes[puid]
 
-        self.app = create_app(__name__, self.tilesets, fuse=self.fuse_process)
+        self.app = create_app(self.name, self.tilesets, fuse=self.fuse_process)
 
         if log_file:
             self.log = None

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -321,7 +321,9 @@ class Server:
     port : int, optional
         The port that this server will run on.
     name : str, optional
-        A name for the Flask app being served
+        A name for the Flask app being served. If not provided, a
+        unique name will be generated. The app's logger inherits this
+        name.
     fuse : bool, optional
         Whether to mount http(s) resources using FUSE.
     tmp_dir : string, optional

--- a/higlass/viewer.py
+++ b/higlass/viewer.py
@@ -156,8 +156,10 @@ def display(
             if track.tileset:
                 tilesets += [track.tileset]
 
-    server = Server(tilesets, host=host, port=server_port, fuse=fuse)
-    server.start(log_level=log_level)
+    server = Server(
+        tilesets, host=host, port=server_port, fuse=fuse, log_level=log_level
+    )
+    server.start()
 
     cloned_views = [View.from_dict(view.to_dict()) for view in views]
 

--- a/higlass/viewer.py
+++ b/higlass/viewer.py
@@ -105,7 +105,7 @@ def display(
     server_port=None,
     dark_mode=False,
     log_level=logging.ERROR,
-    no_fuse=False,
+    fuse=True,
 ):
     """
     Instantiate a HiGlass display with the given views.
@@ -121,8 +121,8 @@ def display(
         server_port: The port on which the internal higlass server will be running on.
         dark_mode: Whether to use dark mode or not.
         log_level: Level of logging to perform.
-        no_fuse: Don't mount the fuse filesystem. Useful if not loading any data
-            over http or https.
+        fuse: Whether to mount the fuse filesystem. Set to false if not loading any
+            data over http or https.
 
     Returns:
         (display: HiGlassDisplay, server: higlass.server.Server, higlass.client.viewconf) tuple
@@ -156,7 +156,7 @@ def display(
             if track.tileset:
                 tilesets += [track.tileset]
 
-    server = Server(tilesets, host=host, port=server_port, no_fuse=no_fuse)
+    server = Server(tilesets, host=host, port=server_port, fuse=fuse)
     server.start(log_level=log_level)
 
     cloned_views = [View.from_dict(view.to_dict()) for view in views]

--- a/test/get_test_data.sh
+++ b/test/get_test_data.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-mkdir -p data
+DATA_DIR=$(dirname "$0")/data
+
+mkdir -p $DATA_DIR
 
 FILES=$(cat <<END
 gene_annotations.short.db
@@ -10,6 +12,6 @@ END
 )
 
 for FILE in $FILES; do
-  [ -e data/$FILE ] || wget -P data/ https://s3.amazonaws.com/pkerp/public/$FILE
+  [ -e data/$FILE ] || wget -P $DATA_DIR https://s3.amazonaws.com/pkerp/public/$FILE
 done
 

--- a/test/tilesets_test.py
+++ b/test/tilesets_test.py
@@ -1,6 +1,9 @@
+import os.path as op
 import higlass.tilesets as hgti
-
 import pandas as pd
+
+
+testdir = op.dirname(op.realpath(__file__))
 
 
 def test_dfpoints():
@@ -18,7 +21,7 @@ def test_dfpoints():
 
 def test_beddb():
     """Test the creation of a beddb tileset."""
-    ts = hgti.beddb("data/gene_annotations.short.db")
+    ts = hgti.beddb(op.join(testdir, "data/gene_annotations.short.db"))
 
     tsinfo = ts.tileset_info()
 
@@ -30,7 +33,7 @@ def test_beddb():
 
 
 def test_bigbed():
-    ts = hgti.bigbed("data/Ctcf_WT_allMot.bed.short.bb")
+    ts = hgti.bigbed(op.join(testdir, "data/Ctcf_WT_allMot.bed.short.bb"))
 
     tsinfo = ts.tileset_info()
 


### PR DESCRIPTION
## Description

What was changed in this pull request?

* Implemented `available-chrom-sizes` endpoint
* `Server`'s logging now defaults to an in-memory stream, stored in `server.log`. Providing a `log_file` will create a rotating file handler instead.
* Since the log's name is inherited from the Flask app name, the Server constructor takes a name parameter, which defaults to `higlass` + a short hash. Getting the logger for a given server will then be `logger = logger.getLogger(server.name)`.

Why is it necessary?

Fixes #46 

## Checklist

- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [x] Updated CHANGELOG.md
- [x] Ran `black` on the root directory
