### PR TITLE
Add proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add constructor for multivec tilesets
 - Added wrapper for bam tileset generator
 - Updated docs to include examples for bam and multivec tilesets
+- Add proxy support
 
 ## [v0.4.4](https://github.com/higlass/higlass-python/compare/v0.4.4...v0.4.3)
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -75,6 +75,21 @@ The ``fuse=False`` option is often necessary if there is no support for FUSE.
 FUSE is only necessary for loading remote http datasets which are not hosted
 on a HiGlass server.
 
+If you can't open a port on your firewall, an alternative is to set up a proxy
+that will forward the requests to HiGlass. For example, you can have `jupyter-server-proxy <https://github.com/jupyterhub/jupyter-server-proxy>`_
+forward all requests based at ``http://REMOTE_IP/proxy/HG_PORT/`` to a local HiGlass
+instance listening at ``HG_PORT``. ``HG_PORT`` can be specified by the
+``server_port`` option or chosen randomly by HiGlass. You can then tell HiGlass
+to use the proxy:
+
+.. code-block:: python
+
+    higlass.display(
+        ...,
+        fuse=False,
+        proxy_base="http://my.remote.ip/proxy/{port}" # {port} will be replaced by the local HiGlass port
+    )
+
 View extent
 -----------
 

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -337,6 +337,10 @@ class Server:
     log_file: str, optional
         Where to write diagnostic log files. Default is to use a
         StringIO stream in memory.
+    root_api_address: str, optional
+        Root path of the reported api_address, instead of http://{host}:{port}.
+        Can be used for redirecting clients to a proxy. Can include {host} and {port}
+        to use these variables.
 
     """
 
@@ -354,6 +358,7 @@ class Server:
         tmp_dir=OS_TEMPDIR,
         log_level=logging.INFO,
         log_file=None,
+        root_api_address=None,
     ):
         self.name = name or __name__.split(".")[0] + "-" + slugid.nice()[:8]
         self.tilesets = tilesets
@@ -374,6 +379,8 @@ class Server:
         else:
             self.log = StringIO()
             handler = logging.StreamHandler(self.log)
+
+        self._root_api_address = root_api_address
 
         handler.setLevel(log_level)
         self.app.logger.addHandler(handler)
@@ -483,4 +490,7 @@ class Server:
 
     @property
     def api_address(self):
-        return "http://{host}:{port}/api/v1".format(host=self.host, port=self.port)
+        if self._root_api_address is None:
+            return "http://{host}:{port}/api/v1".format(host=self.host, port=self.port)
+        root = self._root_api_address.format(host=self.host, port=self.port)
+        return "{}/api/v1".format(root)

--- a/higlass/viewer.py
+++ b/higlass/viewer.py
@@ -108,6 +108,7 @@ def display(
     log_level=logging.ERROR,
     fuse=True,
     auth_token=None,
+    proxy_base=None,
 ):
     """
     Instantiate a HiGlass display with the given views.
@@ -130,6 +131,7 @@ def display(
         log_level: Level of logging to perform.
         fuse: Whether to mount the fuse filesystem. Set to False if not loading any
             data over http or https.
+        proxy_base: Url and base path of server to use as proxy for the client
 
     Returns:
         (display: HiGlassDisplay, server: higlass.server.Server, higlass.client.viewconf) tuple
@@ -164,7 +166,12 @@ def display(
                 tilesets += [track.tileset]
 
     server = Server(
-        tilesets, host=host, port=server_port, fuse=fuse, log_level=log_level
+        tilesets,
+        host=host,
+        port=server_port,
+        fuse=fuse,
+        log_level=log_level,
+        root_api_address=proxy_base,
     )
     server.start()
 


### PR DESCRIPTION
## Description

Added support for higlass-python to sit behind a proxy. This is useful for example when running jupyter-notebook on a remote server with a firewall. In this case, the browser can't connect to the higlass backend directly. This PR allows the user to give the base URL to use when accessing the backend.

## Checklist

- [x] Unit tests added or updated
- [x] Documentation added or updated
- [x] Updated CHANGELOG.md
- [x] Ran `black` on the root directory
