### PR TITLE
Bumped react version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Next
 
+- Bumped React version dependency to ensure compatibility with latest
+  Juptyerlab
+
+## [v0.4.5](https://github.com/higlass/higlass-python/compare/v0.4.5...v0.4.4)
+
 - Add constructor for multivec tilesets
 - Added wrapper for bam tileset generator
 - Updated docs to include examples for bam and multivec tilesets

--- a/js/package.json
+++ b/js/package.json
@@ -36,8 +36,8 @@
     "higlass-multivec": "^0.2.1",
     "lodash": "^4.17.4",
     "pixi.js": "^5.3.0",
-    "react": "^16.5.1",
-    "react-dom": "^16.5.1",
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0",
     "style-loader": "^0.19.0"
   },
   "jupyterlab": {


### PR DESCRIPTION
## Description

What was changed in this pull request?

Bumped react dependency in package.json to version 17.

Why is it necessary?

So that it's compatible with the latest jupyterlab. See https://github.com/higlass/higlass/issues/1045

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Update `examples.ipynb` notebook
- [ ] Documentation added or updated
- [x] Updated CHANGELOG.md
- [ ] Ran `black` on the root directory
