### PR TITLE
Add server-side unix sockets support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added wrapper for bam tileset generator
 - Updated docs to include examples for bam and multivec tilesets
 - Add proxy support
+- Add support for listening on a unix socket
 
 ## [v0.4.4](https://github.com/higlass/higlass-python/compare/v0.4.4...v0.4.3)
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -90,6 +90,32 @@ to use the proxy:
         proxy_base="http://my.remote.ip/proxy/{port}" # {port} will be replaced by the local HiGlass port
     )
 
+Using UNIX sockets
+------------------
+
+You can tell HiGlass to listen on a UNIX socket instead of opening a port. This can be useful for ensuring no remote access to the higlass daemon (since you need filesystem access) and to limit users from accessing each other’s higlass daemons (via filesystem permissions).
+
+To do that, simply pass the path to the socket in the `host` parameter, prefixed with `unix://`:
+
+.. code-block:: python
+
+    higlass.display(
+        ...,
+        host="unix:///tmp/higlass/socket.sock",
+        fuse=False
+    )
+
+You can also pass a directory (marked with a trailing slash) to `host`, and use `server_port` as the filename component. If `server_port` is `None`, a filename will be generated automatically:
+
+.. code-block:: python
+
+    higlass.display(
+        ...,
+        host="unix:///tmp/higlass_servers/",
+        server_port=None,
+        fuse=False
+    )
+
 View extent
 -----------
 

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -428,15 +428,20 @@ class Server:
 
         self._use_unix = self.host.startswith("unix://")
         if not self._use_unix:
+            # Use a regular TCP socket, host and port are as usual
             if self.port is None:
                 self.port = get_open_port()
             self._unix_filename = None
         else:
+            # Use a UNIX socket, host should be a file path prefixed with unix://
+            # If host is a directory, make it a filename by joining it with
+            # the port field.
             host_no_schema = self.host[7:]
             if host_no_schema[-1] == '/':
                 os.makedirs(host_no_schema, mode=0o700, exist_ok=True)
             if op.isdir(host_no_schema):
                 if self.port is None:
+                    # If no port is given, find a free filename and use that
                     self.port = get_free_socket(host_no_schema)
                 self.host = op.join(self.host, str(self.port))
             self._unix_filename = self.host[7:]

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -537,6 +537,6 @@ class Server:
     @property
     def api_address(self):
         if self._root_api_address is None:
-            return self._get_url('')
+            return self._get_url('api/v1')
         root = self._root_api_address.format(host=self.host, port=self.port, unix_filename=self._unix_filename or '')
         return "{}/api/v1".format(root)

--- a/higlass/server.py
+++ b/higlass/server.py
@@ -466,7 +466,7 @@ class Server:
                 r = requests.head(url)
                 if r.ok:
                     self.connected = True
-            except requests.ConnectionError as e:
+            except requests.ConnectionError:
                 time.sleep(0.2)
 
     def _get_url(self, path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ ipywidgets>=7.5
 matplotlib
 multiprocess
 requests
+requests-unixsocket
 sh
 simple-httpfs>=0.4.2
 slugid>=2.0.0

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -1,0 +1,69 @@
+from unittest.mock import Mock, patch
+
+import higlass.server as server
+
+def test_tcp():
+    s = server.Server([], host='localhost', port=1234)
+    with patch('requests.head') as head, patch('multiprocess.Process') as mp:
+        head.ok = True
+        s.start()
+
+    expected_api_address = 'http://localhost:1234/api/v1'
+    assert s.api_address == expected_api_address
+
+def test_tcp_root_api_address():
+    s = server.Server([], host='localhost', port=1234, root_api_address="http://{host}:{port}/test")
+    with patch('requests.head') as head, patch('multiprocess.Process') as mp:
+        head.ok = True
+        s.start()
+
+    expected_api_address = 'http://localhost:1234/test/api/v1'
+    assert s.api_address == expected_api_address
+
+def test_unix_host_file():
+    filename = "/tmp/s.sock"
+    s = server.Server([], host=f'unix://{filename}')
+    with patch('requests.head') as head, patch('multiprocess.Process') as mp:
+        head.ok = True
+        s.start()
+
+    expected_api_address = 'http+unix://' + filename.replace('/', '%2F') + '/api/v1'
+    assert s.api_address == expected_api_address
+
+def test_unix_host_dir_with_port():
+    filename = "/tmp/s.sock"
+    s = server.Server([], host=f'unix:///tmp', port='s.sock')
+    with patch('requests.head') as head,\
+         patch('multiprocess.Process') as mp,\
+         patch('os.makedirs') as _:
+        head.ok = True
+        import pdb
+        pdb.set_trace()
+        s.start()
+
+    expected_api_address = 'http+unix://' + filename.replace('/', '%2F') + '/api/v1'
+    assert s.api_address == expected_api_address
+
+def test_unix_host_dir_without_port():
+    filename = "/tmp/0"
+    s = server.Server([], host=f'unix:///tmp', port=None)
+    with patch('requests.head') as head,\
+         patch('higlass.server.get_free_socket', return_value=0) as _,\
+         patch('multiprocess.Process') as mp,\
+         patch('os.makedirs') as _:
+        head.ok = True
+        s.start()
+
+    expected_api_address = 'http+unix://' + filename.replace('/', '%2F') + '/api/v1'
+    assert s.api_address == expected_api_address
+
+def test_unix_root_api_address():
+    filename = "/tmp/s.sock"
+    s = server.Server([], host=f'unix://{filename}', root_api_address="http+unix://{unix_filename}/test")
+    with patch('requests.head') as head, patch('multiprocess.Process') as mp:
+        head.ok = True
+        s.start()
+
+    expected_api_address = f'http+unix://{filename}/test/api/v1'
+    assert s.api_address == expected_api_address
+


### PR DESCRIPTION
## Description

Passing a host that starts with 'unix://' will make the server bind a unix socket. Host can be a directory, and in this case port will be a filename inside this directory. If host is a directory and port is None, a free 'port' (filename) will be found.

Why is it necessary?

It's useful to ensure no remote access to the higlass daemon (since you need filesystem access) and to limit users from accessing each other’s higlass daemons (via filesystem permissions).

## Checklist

- [x] Unit tests added or updated
- [ ] Update `examples.ipynb` notebook
- [x] Documentation added or updated
- [x] Updated CHANGELOG.md
- [x] Ran `black` on the root directory
