### PR TITLE
Bump matplotlib and pillow versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ flask
 flask-cors
 fusepy
 ipywidgets>=7.5
-matplotlib
+matplotlib==3.5.4
+pillow==8.3.0
 multiprocess
 requests
 requests-unixsocket

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flask
 flask-cors
 fusepy
 ipywidgets>=7.5
-matplotlib==3.5.4
+matplotlib==3.5.1
 pillow==8.3.0
 multiprocess
 requests


### PR DESCRIPTION
## Description

What was changed in this pull request?

- Bumped matplotlib and pillow versions

Why is it necessary?

- To fix security issues with an older version of pillow

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Update `examples.ipynb` notebook
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
- [ ] Ran `black` on the root directory
