### PR TITLE
Bump pillow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ flask-cors
 fusepy
 ipywidgets>=7.5
 matplotlib==3.5.1
-pillow==8.3.0
+pillow>=8.3.0
 multiprocess
 requests
 requests-unixsocket


### PR DESCRIPTION
## Description

What was changed in this pull request?

- Bump pillow version

Why is it necessary?

- So that it's compatible with higlass-server

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Update `examples.ipynb` notebook
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
- [ ] Ran `black` on the root directory
