### PR TITLE
Bumped higlass version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v0.4.8](https://github.com/higlass/higlass-python/compare/v0.4.8...v0.4.7)
+
+- Bumped higlass version
+
 ## [v0.4.7](https://github.com/higlass/higlass-python/compare/v0.4.7...v0.4.6)
 
 - Bumped pillow version

--- a/js/package.json
+++ b/js/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@jupyter-widgets/base": "^1 || ^2 || ^3",
     "css-loader": "^0.28.7",
-    "higlass": "^1.11.8",
+    "higlass": "^1.11.9",
     "higlass-multivec": "^0.2.1",
     "lodash": "^4.17.4",
     "pixi.js": "^5.3.0",


### PR DESCRIPTION
## Description

What was changed in this pull request?

- Bumped the higlass version to 1.11.9

Why is it necessary?

- To have the latest higlass client


Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Update `examples.ipynb` notebook
- [ ] Documentation added or updated
- [x] Updated CHANGELOG.md
- [ ] Ran `black` on the root directory
