### PR TITLE
fix: insert viewconf into HTML repr template

### DIFF
--- a/src/higlass/_display.py
+++ b/src/higlass/_display.py
@@ -74,7 +74,7 @@ def viewconf_to_html(
         URLs for plugin tracks or data fetchers to be loaded on the page.
     """
     return HTML_TEMPLATE.render(
-        spec=json.dumps(viewconf, **(json_kwds or {})),
+        viewconf=json.dumps(viewconf, **(json_kwds or {})),
         higlass_version=higlass_version,
         react_version=react_version,
         pixijs_version=pixijs_version,

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -37,7 +37,12 @@ def test_html_renderer():
     default_renderer = renderers.get()
     assert isinstance(default_renderer, HTMLRenderer)
 
-    mimebundle = default_renderer({})
+    mimebundle = default_renderer(
+        {
+            "foo": "bar",
+        }
+    )
 
     assert "text/html" in mimebundle
     assert 'id="jupyter-hg-' in mimebundle["text/html"]
+    assert '"foo": "bar"' in mimebundle["text/html"]


### PR DESCRIPTION
- fix: rename of viewconf in HTML repr
- test: add test to ensure viewconf in repr

## Description

Fixes HTML renderer that didn't include the view conf after a rename
