### PR TITLE
fix: serialize hg.Viewconf as dict

### DIFF
--- a/src/higlass/_display.py
+++ b/src/higlass/_display.py
@@ -26,7 +26,7 @@ HTML_TEMPLATE = jinja2.Template(
     import hglib from "https://esm.sh/higlass@{{ higlass_version }}?deps=react@{{ react_version }},react-dom@{{ react_version }},pixi.js@{{ pixijs_version }}";
     hglib.viewer(
       document.getElementById('{{ output_div }}'),
-      JSON.parse({{ viewconf }}),
+      {{ viewconf }},
     );
     </script>
 </html>

--- a/src/higlass/api.py
+++ b/src/higlass/api.py
@@ -383,7 +383,7 @@ class Viewconf(hgs.Viewconf[View[TrackT]], _PropertiesMixin, Generic[TrackT]):
         """ "Displays the view config in an IPython environment."""
         renderer = display.renderers.get()
         plugin_urls = [] if self.views is None else gather_plugin_urls(self.views)
-        return renderer(self.json(), plugin_urls=plugin_urls)
+        return renderer(self.dict(), plugin_urls=plugin_urls)
 
     def widget(self):
         """Create a Jupyter Widget display for this view config."""
@@ -648,8 +648,23 @@ class _TrackCreator(BaseModel):
     __root__: Track
 
 
+@overload
+def track(type_: hgs.EnumTrackType, uid: str | None = None, **kwargs) -> EnumTrack:
+    ...
+
+
+@overload
+def track(type_: Literal["heatmap"], uid: str | None = None, **kwargs) -> HeatmapTrack:
+    ...
+
+
+@overload
+def track(type_: str, uid: str | None = None, **kwargs) -> PluginTrack:
+    ...
+
+
 def track(
-    type_: utils.TrackType,
+    type_: hgs.EnumTrackType | Literal["heatmap"] | str,
     uid: str | None = None,
     **kwargs,
 ) -> Track:


### PR DESCRIPTION
## Description

What was changed in this pull request?

Correctly serializes a `hg.Viewconf` as a `dict` for custom renderers.

Why is it necessary?

Previously custom renderers would need to handle JSON.

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Update `examples.ipynb` notebook
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
- [ ] Ran `black` on the root directory
