### PR TITLE
Add partition scale class

### DIFF
--- a/src/higlass/_scale.py
+++ b/src/higlass/_scale.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools
 from bisect import bisect_right
-from typing import Tuple
+from typing import Iterable, Tuple
 
 GenomicPosition = Tuple[str, int]
 

--- a/src/higlass/_scale.py
+++ b/src/higlass/_scale.py
@@ -35,7 +35,7 @@ class Scale:
 
     def __init__(
         self,
-        chromsizes: dict | list[tuple],
+        chromsizes: dict[str, int] | Iterable[tuple[str, int]],
         binsize: int = 1,
     ):
         chromsizes = dict(chromsizes)

--- a/src/higlass/_scale.py
+++ b/src/higlass/_scale.py
@@ -67,9 +67,7 @@ class Scale:
         return self._chrom_offsets[-1]
 
     def __repr__(self) -> str:
-        return (
-            f"Scale(chromsizes={self._chrom_lengths_map}, binsize={self._binsize})"
-        )
+        return f"Scale(chromsizes={self._chrom_lengths_map}, binsize={self._binsize})"
 
     def __call__(self, gpos: GenomicPosition) -> int:
         """

--- a/src/higlass/_scale.py
+++ b/src/higlass/_scale.py
@@ -1,21 +1,21 @@
 from __future__ import annotations
+
+import itertools
 from bisect import bisect_right
 from typing import Tuple
-import itertools
-
 
 GenomicPosition = Tuple[str, int]
 
 
 class Scale:
     """
-    A bidirectional mapping between a composite genomic coordinate system and 
+    A bidirectional mapping between a composite genomic coordinate system and
     a partition of that coordinate system into a sequence of bins.
 
     The partition is a 1D array of bins of a fixed size, with the exception of
     the last bin in each chromosome, which may be smaller than the fixed size.
     The scale provides a mapping from a genomic coordinate to the index of the
-    bin in which it falls, and a mapping from a bin index to the genomic 
+    bin in which it falls, and a mapping from a bin index to the genomic
     coordinate of the bin's start.
 
     Parameters
@@ -28,12 +28,13 @@ class Scale:
 
     Notes
     -----
-    The genomic coordinates are 0-based and the bins of the partition are 
-    half-open intervals, i.e. the start coordinate of a bin is included in the 
+    The genomic coordinates are 0-based and the bins of the partition are
+    half-open intervals, i.e. the start coordinate of a bin is included in the
     bin, but the end is not.
     """
+
     def __init__(
-        self, 
+        self,
         chromsizes: dict | list[tuple],
         binsize: int = 1,
     ):

--- a/src/higlass/_scale.py
+++ b/src/higlass/_scale.py
@@ -76,3 +76,10 @@ class Scale:
         different bin size.
         """
         return Scale(self._chrom_lengths_map, binsize)
+
+    @property
+    def chromsizes(self) -> dict[str, int]:
+        """
+        A dictionary of the ordered chromosome names and lengths.
+        """
+        return self._chrom_lengths_map

--- a/src/higlass/_scale.py
+++ b/src/higlass/_scale.py
@@ -39,7 +39,7 @@ class Scale:
         binsize: int = 1,
     ):
         chromsizes = dict(chromsizes)
-        names, lengths = list(chromsizes.keys()), list(chromsizes.values())
+        names, lengths = zip(*chromsizes.items())
         lengths_binned = [(length + binsize - 1) // binsize for length in lengths]
         chrom_offsets = list(itertools.accumulate(lengths_binned, initial=0))
         self._chrom_names = names

--- a/src/higlass/_scale.py
+++ b/src/higlass/_scale.py
@@ -66,10 +66,7 @@ class Scale:
         """
         Returns the genomic position of the start of the bin at the given index.
         """
-        if offset < 0:
-            offset = 0
-        if offset >= self.n_bins:
-            offset = self.n_bins - 1
+        offset = max(0, min(offset, self.n_bins - 1))
         i = bisect_right(self._chrom_offsets, offset)
         chrom = self._chrom_names[i - 1]
         rel_offset = offset - self._chrom_offsets[i - 1]

--- a/src/higlass/_scale.py
+++ b/src/higlass/_scale.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+from bisect import bisect_right
+from typing import Tuple
+import itertools
+
+
+GenomicPosition = Tuple[str, int]
+
+
+class Scale:
+    """
+    A bidirectional mapping between a composite genomic coordinate system and 
+    a partition of that coordinate system into a sequence of bins.
+
+    The partition is a 1D array of bins of a fixed size, with the exception of
+    the last bin in each chromosome, which may be smaller than the fixed size.
+    The scale provides a mapping from a genomic coordinate to the index of the
+    bin in which it falls, and a mapping from a bin index to the genomic 
+    coordinate of the bin's start.
+
+    Parameters
+    ----------
+    chromsizes : dict | list[tuple]
+        A dictionary of chromosome names and lengths or a list of tuples
+        of chromosome names and lengths.
+    binsize : int
+        The size of each bin in the partition in bp.
+
+    Notes
+    -----
+    The genomic coordinates are 0-based and the bins of the partition are 
+    half-open intervals, i.e. the start coordinate of a bin is included in the 
+    bin, but the end is not.
+    """
+    def __init__(
+        self, 
+        chromsizes: dict | list[tuple],
+        binsize: int = 1,
+    ):
+        chromsizes = dict(chromsizes)
+        names, lengths = list(chromsizes.keys()), list(chromsizes.values())
+        lengths_binned = [(length + binsize - 1) // binsize for length in lengths]
+        chrom_offsets = list(itertools.accumulate(lengths_binned, initial=0))
+        self._chrom_names = names
+        self._chrom_offsets = chrom_offsets
+        self._chrom_lengths_map = chromsizes
+        self._chrom_offsets_map = dict(zip(names, chrom_offsets[:-1]))
+        self.n_bins = chrom_offsets[-1]
+        self.binsize = binsize
+
+    def offset(self, gpos: GenomicPosition) -> int:
+        """
+        Returns the index of the bin in which the given genomic position falls.
+        """
+        chrom, pos = gpos
+        chrom_offset = self._chrom_offsets_map[chrom]
+        clen = self._chrom_lengths_map[chrom]
+        if pos < 0:
+            pos = 0
+        if pos >= clen:
+            pos = clen - 1
+        return chrom_offset + pos // self.binsize
+
+    def invert(self, offset: int) -> GenomicPosition:
+        """
+        Returns the genomic position of the start of the bin at the given index.
+        """
+        if offset < 0:
+            offset = 0
+        if offset >= self.n_bins:
+            offset = self.n_bins - 1
+        i = bisect_right(self._chrom_offsets, offset)
+        chrom = self._chrom_names[i - 1]
+        rel_offset = offset - self._chrom_offsets[i - 1]
+        return chrom, rel_offset * self.binsize

--- a/src/higlass/_scale.py
+++ b/src/higlass/_scale.py
@@ -15,8 +15,9 @@ class Scale:
     The partition is a sequence of bins of a fixed size, with the exception of
     the last bin in each chromosome, which may be smaller than the fixed size.
     Bins do not cross chromosome boundaries. The scale provides a mapping from
-    a genomic coordinate to the index of the bin in which it falls, and a
-    mapping from a bin index to the genomic coordinate of the bin's start.
+    a genomic coordinate to the index of the bin in which it falls, and an
+    inverse mapping from a bin index to the genomic coordinate of the bin's
+    start.
 
     Parameters
     ----------
@@ -49,25 +50,22 @@ class Scale:
         self.n_bins = chrom_offsets[-1]
         self.binsize = binsize
 
-    def offset(self, gpos: GenomicPosition) -> int:
+    def __call__(self, gpos: GenomicPosition) -> int:
         """
         Returns the index of the bin in which the given genomic position falls.
         """
         chrom, pos = gpos
         chrom_offset = self._chrom_offsets_map[chrom]
         clen = self._chrom_lengths_map[chrom]
-        if pos < 0:
-            pos = 0
-        if pos >= clen:
-            pos = clen - 1
+        pos = max(0, min(pos, clen - 1))
         return chrom_offset + pos // self.binsize
 
-    def invert(self, offset: int) -> GenomicPosition:
+    def invert(self, index: int) -> GenomicPosition:
         """
         Returns the genomic position of the start of the bin at the given index.
         """
-        offset = max(0, min(offset, self.n_bins - 1))
-        i = bisect_right(self._chrom_offsets, offset)
+        index = max(0, min(index, self.n_bins - 1))
+        i = bisect_right(self._chrom_offsets, index)
         chrom = self._chrom_names[i - 1]
-        rel_offset = offset - self._chrom_offsets[i - 1]
+        rel_offset = index - self._chrom_offsets[i - 1]
         return chrom, rel_offset * self.binsize

--- a/src/higlass/_scale.py
+++ b/src/higlass/_scale.py
@@ -23,8 +23,8 @@ class Scale:
     chromsizes : dict | list[tuple]
         A dictionary of chromosome names and lengths or a list of tuples
         of chromosome names and lengths.
-    binsize : int
-        The size of each bin in the partition in bp.
+    binsize : int, optional
+        The size of each bin in the partition in bp (default: 1).
 
     Notes
     -----

--- a/src/higlass/_scale.py
+++ b/src/higlass/_scale.py
@@ -69,3 +69,10 @@ class Scale:
         chrom = self._chrom_names[i - 1]
         rel_offset = index - self._chrom_offsets[i - 1]
         return chrom, rel_offset * self.binsize
+
+    def rebin(self, binsize: int) -> Scale:
+        """
+        Returns a new scale with the same genomic coordinate system but a
+        different bin size.
+        """
+        return Scale(self._chrom_lengths_map, binsize)

--- a/src/higlass/_scale.py
+++ b/src/higlass/_scale.py
@@ -12,11 +12,11 @@ class Scale:
     A bidirectional mapping between a composite genomic coordinate system and
     a partition of that coordinate system into a sequence of bins.
 
-    The partition is a 1D array of bins of a fixed size, with the exception of
+    The partition is a sequence of bins of a fixed size, with the exception of
     the last bin in each chromosome, which may be smaller than the fixed size.
-    The scale provides a mapping from a genomic coordinate to the index of the
-    bin in which it falls, and a mapping from a bin index to the genomic
-    coordinate of the bin's start.
+    Bins do not cross chromosome boundaries. The scale provides a mapping from
+    a genomic coordinate to the index of the bin in which it falls, and a
+    mapping from a bin index to the genomic coordinate of the bin's start.
 
     Parameters
     ----------

--- a/test/test_scale.py
+++ b/test/test_scale.py
@@ -62,3 +62,11 @@ def test_rebin(scale):
     assert scale.n_bins == 60
     assert new_scale.binsize == 500
     assert new_scale.n_bins == 120
+
+
+def test_chromsizes(scale):
+    assert scale.chromsizes == {
+        "chr1": 10000,
+        "chr2": 20000,
+        "chr3": 30000,
+    }

--- a/test/test_scale.py
+++ b/test/test_scale.py
@@ -54,3 +54,11 @@ def test_call_out_of_bounds(scale):
 def test_invert_out_of_bounds(scale):
     assert scale.invert(-1) == ("chr1", 0)
     assert scale.invert(60) == ("chr3", 29000)
+
+
+def test_rebin(scale):
+    new_scale = scale.rebin(500)
+    assert scale.binsize == 1000
+    assert scale.n_bins == 60
+    assert new_scale.binsize == 500
+    assert new_scale.n_bins == 120

--- a/test/test_scale.py
+++ b/test/test_scale.py
@@ -1,0 +1,55 @@
+import pytest
+from higlass._scale import Scale
+
+
+@pytest.fixture
+def scale():
+    chromsizes = [('chr1', 10000), ('chr2', 20000), ('chr3', 30000)]
+    binsize = 1000
+    return Scale(chromsizes, binsize)
+
+
+def get_data():
+    return [
+        (('chr1', 0), 0, ('chr1', 0)),
+        (('chr1', 900), 0, ('chr1', 0)),
+        (('chr1', 1000), 1, ('chr1', 1000)),
+        (('chr1', 9000), 9, ('chr1', 9000)),
+        (('chr1', 9999), 9, ('chr1', 9000)),
+        (('chr1', 10000), 9, ('chr1', 9000)),
+        (('chr1', 100000), 9, ('chr1', 9000)),
+        (('chr2', 0), 10, ('chr2', 0)),
+        (('chr2', 900), 10, ('chr2', 0)),
+        (('chr2', 1000), 11, ('chr2', 1000)),
+        (('chr2', 19000), 29, ('chr2', 19000)),
+        (('chr2', 19999), 29, ('chr2', 19000)),
+        (('chr2', 20000), 29, ('chr2', 19000)),
+        (('chr2', 100000), 29, ('chr2', 19000)),
+        (('chr3', 0), 30, ('chr3', 0)),
+        (('chr3', 900), 30, ('chr3', 0)),
+        (('chr3', 1000), 31, ('chr3', 1000)),
+        (('chr3', 29000), 59, ('chr3', 29000)),
+        (('chr3', 29999), 59, ('chr3', 29000)),
+        (('chr3', 30000), 59, ('chr3', 29000)),
+        (('chr3', 100000), 59, ('chr3', 29000)),
+    ]
+
+
+@pytest.mark.parametrize("gpos, offset, binstart", get_data())
+def test_offset(scale, gpos, offset, binstart):    
+    assert scale.offset(gpos) == offset
+
+
+@pytest.mark.parametrize("gpos, offset, binstart", get_data())
+def test_invert(scale, gpos, offset, binstart):
+    assert scale.invert(offset) == binstart
+
+
+def test_offset_out_of_bounds(scale):
+    assert scale.offset(('chr1', -1)) == 0
+    assert scale.offset(('chr3', 30000)) == 59
+
+
+def test_invert_out_of_bounds(scale):
+    assert scale.invert(-1) == ('chr1', 0)
+    assert scale.invert(60) == ('chr3', 29000)

--- a/test/test_scale.py
+++ b/test/test_scale.py
@@ -10,6 +10,7 @@ def scale():
 
 
 def get_data():
+    # (gpos, offset, binstart)
     return [
         (("chr1", 0), 0, ("chr1", 0)),
         (("chr1", 900), 0, ("chr1", 0)),
@@ -36,8 +37,8 @@ def get_data():
 
 
 @pytest.mark.parametrize("gpos, offset, binstart", get_data())
-def test_offset(scale, gpos, offset, binstart):
-    assert scale.offset(gpos) == offset
+def test_call(scale, gpos, offset, binstart):
+    assert scale(gpos) == offset
 
 
 @pytest.mark.parametrize("gpos, offset, binstart", get_data())
@@ -45,9 +46,9 @@ def test_invert(scale, gpos, offset, binstart):
     assert scale.invert(offset) == binstart
 
 
-def test_offset_out_of_bounds(scale):
-    assert scale.offset(("chr1", -1)) == 0
-    assert scale.offset(("chr3", 30000)) == 59
+def test_call_out_of_bounds(scale):
+    assert scale(("chr1", -1)) == 0
+    assert scale(("chr3", 30000)) == 59
 
 
 def test_invert_out_of_bounds(scale):

--- a/test/test_scale.py
+++ b/test/test_scale.py
@@ -4,39 +4,39 @@ from higlass._scale import Scale
 
 @pytest.fixture
 def scale():
-    chromsizes = [('chr1', 10000), ('chr2', 20000), ('chr3', 30000)]
+    chromsizes = [("chr1", 10000), ("chr2", 20000), ("chr3", 30000)]
     binsize = 1000
     return Scale(chromsizes, binsize)
 
 
 def get_data():
     return [
-        (('chr1', 0), 0, ('chr1', 0)),
-        (('chr1', 900), 0, ('chr1', 0)),
-        (('chr1', 1000), 1, ('chr1', 1000)),
-        (('chr1', 9000), 9, ('chr1', 9000)),
-        (('chr1', 9999), 9, ('chr1', 9000)),
-        (('chr1', 10000), 9, ('chr1', 9000)),
-        (('chr1', 100000), 9, ('chr1', 9000)),
-        (('chr2', 0), 10, ('chr2', 0)),
-        (('chr2', 900), 10, ('chr2', 0)),
-        (('chr2', 1000), 11, ('chr2', 1000)),
-        (('chr2', 19000), 29, ('chr2', 19000)),
-        (('chr2', 19999), 29, ('chr2', 19000)),
-        (('chr2', 20000), 29, ('chr2', 19000)),
-        (('chr2', 100000), 29, ('chr2', 19000)),
-        (('chr3', 0), 30, ('chr3', 0)),
-        (('chr3', 900), 30, ('chr3', 0)),
-        (('chr3', 1000), 31, ('chr3', 1000)),
-        (('chr3', 29000), 59, ('chr3', 29000)),
-        (('chr3', 29999), 59, ('chr3', 29000)),
-        (('chr3', 30000), 59, ('chr3', 29000)),
-        (('chr3', 100000), 59, ('chr3', 29000)),
+        (("chr1", 0), 0, ("chr1", 0)),
+        (("chr1", 900), 0, ("chr1", 0)),
+        (("chr1", 1000), 1, ("chr1", 1000)),
+        (("chr1", 9000), 9, ("chr1", 9000)),
+        (("chr1", 9999), 9, ("chr1", 9000)),
+        (("chr1", 10000), 9, ("chr1", 9000)),
+        (("chr1", 100000), 9, ("chr1", 9000)),
+        (("chr2", 0), 10, ("chr2", 0)),
+        (("chr2", 900), 10, ("chr2", 0)),
+        (("chr2", 1000), 11, ("chr2", 1000)),
+        (("chr2", 19000), 29, ("chr2", 19000)),
+        (("chr2", 19999), 29, ("chr2", 19000)),
+        (("chr2", 20000), 29, ("chr2", 19000)),
+        (("chr2", 100000), 29, ("chr2", 19000)),
+        (("chr3", 0), 30, ("chr3", 0)),
+        (("chr3", 900), 30, ("chr3", 0)),
+        (("chr3", 1000), 31, ("chr3", 1000)),
+        (("chr3", 29000), 59, ("chr3", 29000)),
+        (("chr3", 29999), 59, ("chr3", 29000)),
+        (("chr3", 30000), 59, ("chr3", 29000)),
+        (("chr3", 100000), 59, ("chr3", 29000)),
     ]
 
 
 @pytest.mark.parametrize("gpos, offset, binstart", get_data())
-def test_offset(scale, gpos, offset, binstart):    
+def test_offset(scale, gpos, offset, binstart):
     assert scale.offset(gpos) == offset
 
 
@@ -46,10 +46,10 @@ def test_invert(scale, gpos, offset, binstart):
 
 
 def test_offset_out_of_bounds(scale):
-    assert scale.offset(('chr1', -1)) == 0
-    assert scale.offset(('chr3', 30000)) == 59
+    assert scale.offset(("chr1", -1)) == 0
+    assert scale.offset(("chr3", 30000)) == 59
 
 
 def test_invert_out_of_bounds(scale):
-    assert scale.invert(-1) == ('chr1', 0)
-    assert scale.invert(60) == ('chr3', 29000)
+    assert scale.invert(-1) == ("chr1", 0)
+    assert scale.invert(60) == ("chr3", 29000)

--- a/test/test_scale.py
+++ b/test/test_scale.py
@@ -9,6 +9,29 @@ def scale():
     return Scale(chromsizes, binsize)
 
 
+def test_chromsizes(scale):
+    assert scale.chromsizes == {
+        "chr1": 10000,
+        "chr2": 20000,
+        "chr3": 30000,
+    }
+
+
+def test_binsize(scale):
+    assert scale.binsize == 1000
+
+
+def test_len(scale):
+    assert len(scale) == 60
+
+
+def test_repr(scale):
+    assert repr(scale) == (
+        "Scale(chromsizes={'chr1': 10000, 'chr2': 20000, 'chr3': 30000}, "
+        "binsize=1000)"
+    )
+
+
 def get_data():
     # (gpos, offset, binstart)
     return [
@@ -59,14 +82,6 @@ def test_invert_out_of_bounds(scale):
 def test_rebin(scale):
     new_scale = scale.rebin(500)
     assert scale.binsize == 1000
-    assert scale.n_bins == 60
+    assert len(scale) == 60
     assert new_scale.binsize == 500
-    assert new_scale.n_bins == 120
-
-
-def test_chromsizes(scale):
-    assert scale.chromsizes == {
-        "chr1": 10000,
-        "chr2": 20000,
-        "chr3": 30000,
-    }
+    assert len(new_scale) == 120


### PR DESCRIPTION
## Description

What was changed in this pull request?

A "partition scale" object to map a composite genomic coordinate system to a partition of its chromosomes into sequential bins.

Why is it necessary?

To simplify the harmonization of the tile partition of HiGlass's scene space at a given zoom level to the often dissimilar partition of the genome used by a data source.

## Checklist

- [x] Unit tests added or updated
- [ ] Update `examples.ipynb` notebook
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
- [x] Ran `black` on the root directory
