### PR TITLE
feat: add __rich_repr__ to hg.Scale"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ urls = { homepage = "https://github.com/higlass/higlass-python" }
 dev = [
     "black[jupyter]",
     "pytest",
-    "ruff==0.0.238",
+    "ruff",
 ]
 fuse = [
     "fusepy",

--- a/src/higlass/_scale.py
+++ b/src/higlass/_scale.py
@@ -67,7 +67,11 @@ class Scale:
         return self._chrom_offsets[-1]
 
     def __repr__(self) -> str:
-        return f"Scale(chromsizes={self._chrom_lengths_map}, binsize={self._binsize})"
+        return f"Scale(chromsizes={self.chromsizes}, binsize={self.binsize})"
+
+    def __rich_repr__(self):
+        yield "chromsizes", list(self.chromsizes.items())
+        yield "binsize", self.binsize
 
     def __call__(self, gpos: GenomicPosition) -> int:
         """


### PR DESCRIPTION
## Description

What was changed in this pull request?

Adds a `__rich_repr__` implementation to `Scale` for pretty printing objects with `rich`.

Why is it necessary?

It's not necessary, but the core API has support for rich repr.

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Update `examples.ipynb` notebook
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
- [ ] Ran `black` on the root directory
