### PR TITLE
feat: temporarily enable a renderer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,7 @@ jobs:
         pip install -e .[dev]
 
     - name: Linting with Ruff
-      # TODO: fix me! For some reason ruff's isorting
-      # doesn't detect higlass as a local module, so
-      # there are differences with import block sorting locally
-      # and in CI. We should hopefully enable this rule in the future.
-      run: |
-        ruff --ignore I001 .
-        ruff src/ # everything seems to be working in src ...
+      run: ruff .
 
     - name: Formatting with Black
       run: black --check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,13 @@ jobs:
         pip install -e .[dev]
 
     - name: Linting with Ruff
-      run: ruff .
+      # TODO: fix me! For some reason ruff's isorting
+      # doesn't detect higlass as a local module, so
+      # there are differences with import block sorting locally
+      # and in CI. We should hopefully enable this rule in the future.
+      run: |
+        ruff --ignore I001 .
+        ruff src/ # everything seems to be working in src ...
 
     - name: Formatting with Black
       run: black --check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
       # doesn't detect higlass as a local module, so
       # there are differences with import block sorting locally
       # and in CI. We should hopefully enable this rule in the future.
-      run: ruff --ignore I001 .
+      run: |
+        ruff --ignore I001 .
+        ruff src/ # everything seems to be working in src ...
 
     - name: Formatting with Black
       run: black --check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ jobs:
         pip install -e .[dev]
 
     - name: Linting with Ruff
-      run: ruff .
+      # TODO: fix me! For some reason ruff's isorting
+      # doesn't detect higlass as a local module, so
+      # there are differences with import block sorting locally
+      # and in CI. We should hopefully enable this rule in the future.
+      run: ruff --ignore I001 .
 
     - name: Formatting with Black
       run: black --check .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,8 +3,9 @@
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from higlass import __version__
 from pkg_resources import parse_version
+
+from higlass import __version__
 
 # -*- coding: utf-8 -*-
 #

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,6 @@ from docutils.parsers.rst import Directive, directives
 from higlass import __version__
 from pkg_resources import parse_version
 
-
 # -*- coding: utf-8 -*-
 #
 # higlass documentation build configuration file, created by

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,9 +3,9 @@
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
+from higlass import __version__
 from pkg_resources import parse_version
 
-from higlass import __version__
 
 # -*- coding: utf-8 -*-
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ extend-select = [
 ]
 
 [tool.ruff.isort]
-known-first-party = ["src"]
+known-first-party = ["src", "test", "doc"]
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ extend-select = [
     "W",  # style  warnings
 ]
 
+[tool.ruff.isort]
+known-first-party = ["src"]
+
 [tool.ruff.per-file-ignores]
 "__init__.py" = [
     "F403", # unused-star-used

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,9 +91,6 @@ extend-select = [
     "W",  # style  warnings
 ]
 
-[tool.ruff.isort]
-known-first-party = ["src", "test", "doc"]
-
 [tool.ruff.per-file-ignores]
 "__init__.py" = [
     "F403", # unused-star-used

--- a/src/higlass/__init__.py
+++ b/src/higlass/__init__.py
@@ -8,6 +8,7 @@ except PackageNotFoundError:
 from higlass_schema import *
 
 import higlass.tilesets
+from higlass._display import renderers
 from higlass.api import *
 from higlass.fuse import fuse
 from higlass.server import server

--- a/src/higlass/_display.py
+++ b/src/higlass/_display.py
@@ -141,12 +141,8 @@ class HTMLRenderer(BaseRenderer):
         return {"text/html": html}
 
 
-class PluginRegistry(Protocol):
-    active: str | None
-
-
 @contextlib.contextmanager
-def managed_enable(registry: PluginRegistry, reset: str | None):
+def managed_enable(registry: RendererRegistry, reset: str | None):
     """Temporarily enables a renderer.
 
     Parameters
@@ -158,13 +154,13 @@ def managed_enable(registry: PluginRegistry, reset: str | None):
         The previous name of the active plugin.
     """
     try:
-        yield registry
+        yield registry.get()
     finally:
         registry.active = reset
 
 
 @dataclass
-class RendererRegistry(PluginRegistry):
+class RendererRegistry:
     """A registery for multiple HiGlass renderers.
 
     Allows for multiple renders to be registered, and dynamically enabled/disabled

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import pytest
 import higlass as hg
+import pytest
 
 
 @pytest.mark.parametrize(

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 import higlass as hg
 
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import higlass as hg
 import pytest
+
+import higlass as hg
 
 
 @pytest.mark.parametrize(

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
-import pytest
 from higlass._display import HTMLRenderer, RendererRegistry, renderers
+import pytest
 
 
 def test_registry():

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from higlass._display import HTMLRenderer, RendererRegistry, renderers
 
 

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -1,7 +1,8 @@
 from unittest.mock import MagicMock
 
-from higlass._display import HTMLRenderer, RendererRegistry, renderers
 import pytest
+
+from higlass._display import HTMLRenderer, RendererRegistry, renderers
 
 
 def test_registry():

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -48,9 +48,9 @@ def test_temporary_renderer():
 
     registry.enable("foo")
 
-    with registry.enable("mock"):
+    with registry.enable("mock") as render:
         assert registry.active == "mock"
-        registry.get()({"hello": "world"})
+        render({"hello": "world"})
 
     mock.assert_called_once_with({"hello": "world"})
 

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -1,4 +1,7 @@
+from unittest.mock import MagicMock
+
 import pytest
+
 from higlass._display import HTMLRenderer, RendererRegistry, renderers
 
 
@@ -28,6 +31,32 @@ def test_registry():
     mimebundle = render({})
 
     assert isinstance(mimebundle, dict)
+    assert mimebundle["text/plain"] == "some content"
+
+
+def test_temporary_renderer():
+    registry = RendererRegistry()
+    mock = MagicMock()
+
+    def renderer(viewconf: dict, **metadata):
+        return {
+            "text/plain": "some content",
+        }
+
+    registry.register("foo", renderer)
+    registry.register("mock", mock)
+
+    registry.enable("foo")
+
+    with registry.enable("mock"):
+        assert registry.active == "mock"
+        registry.get()({"hello": "world"})
+
+    mock.assert_called_once_with({"hello": "world"})
+
+    render = registry.get()
+    mimebundle = render({})
+    assert registry.active == "foo"
     assert mimebundle["text/plain"] == "some content"
 
 

--- a/test/test_scale.py
+++ b/test/test_scale.py
@@ -1,5 +1,4 @@
 import pytest
-
 from higlass._scale import Scale
 
 

--- a/test/test_scale.py
+++ b/test/test_scale.py
@@ -1,4 +1,5 @@
 import pytest
+
 from higlass._scale import Scale
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import pytest
-from higlass._utils import copy_unique, ensure_list
 from pydantic import BaseModel
+
+from higlass._utils import copy_unique, ensure_list
 
 
 def test_copy_unique():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import BaseModel
 from higlass._utils import copy_unique, ensure_list
+from pydantic import BaseModel
 
 
 def test_copy_unique():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 from pydantic import BaseModel
-
 from higlass._utils import copy_unique, ensure_list
 
 


### PR DESCRIPTION
## Description

What was changed in this pull request?

Adds a context manager to `higlass._display.RendererRegistry`, which allows for temporarily enabling a renderer with a context manager.

```python
with hg.renderers.enable("custom") as custom_render:
    custom_render(...)

assert hg.renderers.active == "default"
```

I think this will be useful for creating a separate (Jupyter-less) renderer for higlass-python, allowing for opening through a script (addressing #95):


For example, a simple script example:


```python
import higlass as hg


def open_browser(conf)
    with hg.renderers.enable("html") as render:
        html = render(conf.dict())
    encoded = urllib.parse.quote(html)
    # there is a limit on data URL sizes, so might need to integrate
    # with hg server here to dynamically create and HTML endpoint
    webbrowser.open("data:text/html," + encoded)


if __name__ == "__main__":
    ts = hg.cooler("../data/dataset.mcool")
    track = ts.track("heatmap")
    view = hg.view(track)
    open_browser(view.viewconf())
    input("Press any key to exit.")
```

Why is it necessary?

Fixes #___

## Checklist

- [x] Unit tests added or updated
- [x] Ran `black` on the root directory
