### PR TITLE
chore: rename primary branch from master -> main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
   pull_request:
-    branches: master
+    branches: main
 
 jobs:
   Lint:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ a fresh python library for [`higlass`](https://github.com/higlass/higlass) built
 on top of [`higlass-schema`](https://github.com/higlass/higlass-schema) and
 [`higlass-widget`](https://github.com/higlass/higlass-widget).
 
-[![License](https://img.shields.io/pypi/l/higlass-python.svg?color=green)](https://github.com/higlass/higlass-python/raw/master/LICENSE)
+[![License](https://img.shields.io/pypi/l/higlass-python.svg?color=green)](https://github.com/higlass/higlass-python/raw/main/LICENSE)
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/higlass/higlass-python/blob/main/notebooks/Examples.ipynb)
 
 ## Usage


### PR DESCRIPTION
## Description

What was changed in this pull request?

Changed `master` to `main`. There is a "migration" prompt if you've already cloned the repo:

![image](https://user-images.githubusercontent.com/24403730/225395541-f966884c-df97-480f-9c3d-20ddb736f3b9.png)


Why is it necessary?

New default branch for git/GitHub. More consistency with `higlass-schema`/ `higlass-widget`.

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Update `examples.ipynb` notebook
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
- [ ] Ran `black` on the root directory
