### PR TITLE
feat: bump higlass to v1.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,28 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: "3.x"
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .[dev]
-
-    - name: Linting with Ruff
-      # TODO: fix me! For some reason ruff's isorting
-      # doesn't detect higlass as a local module, so
-      # there are differences with import block sorting locally
-      # and in CI. We should hopefully enable this rule in the future.
-      run: |
-        ruff --ignore I001 .
-        ruff src/ # everything seems to be working in src ...
-
-    - name: Formatting with Black
-      run: black --check .
+    - run: |
+        python -m pip install --upgrade hatch
+        hatch run lint
 
   Test:
     runs-on: ubuntu-latest
@@ -45,19 +30,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Install dependencies
-      run: |
+    - run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
-
-    - name: Test with pytest
-      run: |
         pytest
 
   Release:

--- a/src/higlass/_display.py
+++ b/src/higlass/_display.py
@@ -37,7 +37,7 @@ HTML_TEMPLATE = jinja2.Template(
 
 def viewconf_to_html(
     viewconf: dict,
-    higlass_version: str = "1.11",
+    higlass_version: str = "1.12",
     react_version: str = "17",
     pixijs_version: str = "6",
     output_div: str = "vis",


### PR DESCRIPTION
## Description

What was changed in this pull request?

Bumps higlass client version in the HTML repr to v1.12.

Why is it necessary?

Fixes rendering issue mentioned in #117

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Update `examples.ipynb` notebook
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
- [ ] Ran `black` on the root directory
