### PR TITLE
Added a workflow to push docs to S3

### DIFF
--- a/.github/workflows/docs_s3.yml
+++ b/.github/workflows/docs_s3.yml
@@ -1,0 +1,42 @@
+name: Deploy documentation to s3 (docs-python.higlass.io)
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: main
+
+# Allow one concurrent deployment
+concurrency:
+  group: "docs_s3"
+  cancel-in-progress: true
+
+jobs:
+  # Deploy docs to S3
+  deploy_s3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch
+
+      - name: Build
+        run: hatch run docs:build
+
+      - name: Publish docs to S3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --delete --exclude '.git/*'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_HIGLASS_S3_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_HIGLASS_S3_SECRET_ACCESS_KEY }}
+          AWS_S3_BUCKET: docs-python.higlass.io
+          SOURCE_DIR: ./docs/_build/html

--- a/src/higlass/tilesets.py
+++ b/src/higlass/tilesets.py
@@ -49,6 +49,7 @@ class LocalTileset:
         return self._info()
 
 
+
 @dataclass
 class RemoteTileset:
     uid: str

--- a/src/higlass/tilesets.py
+++ b/src/higlass/tilesets.py
@@ -49,7 +49,6 @@ class LocalTileset:
         return self._info()
 
 
-
 @dataclass
 class RemoteTileset:
     uid: str


### PR DESCRIPTION
Added a workflow to push docs to S3.

Why is it necessary?

When the docs page is pushed to the docs-python.higlass.io bucket, they end up in on http://docs-python.higlass.io

Fixes #___

## Checklist

- [o] Unit tests added or updated
- [o] Update `examples.ipynb` notebook
- [o] Documentation added or updated
- [o] Updated CHANGELOG.md
- [o] Ran `black` on the root directory
