### PR TITLE
feat: move HiGlassWidget to higlass-python

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import typing
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -213,7 +214,7 @@ class IframeVideo(Directive):
     required_arguments = 1
     optional_arguments = 0
     final_argument_whitespace = False
-    option_spec = {
+    option_spec: typing.ClassVar = {
         "height": directives.nonnegative_int,
         "width": directives.nonnegative_int,
         "align": align,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ readme = "README.md"
 dependencies = [
     "servir>=0.0.5",
     "higlass-schema>=0.0.6",
-    "higlass-widget>=0.0.7",
+    "anywidget>=0.6.3",
     "jinja2",
     "jupyter-server-proxy>=3.0",
     "typing-extensions ; python_version<'3.9'",
@@ -41,6 +41,7 @@ dev = [
     "pytest",
     "ruff",
     "jupyterlab",
+    "anywidget[dev]>=0.6.3",
 ]
 docs = [
     "Sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ urls = { homepage = "https://github.com/higlass/higlass-python" }
 dev = [
     "black[jupyter]",
     "pytest",
-    "ruff",
+    "ruff==0.0.285",
     "jupyterlab",
     "anywidget[dev]>=0.6.3",
 ]

--- a/src/higlass/_widget.py
+++ b/src/higlass/_widget.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import pathlib
+
+import anywidget
+import traitlets as t
+
+
+class HiGlassWidget(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "widget.js"
+    _css = "https://esm.sh/higlass@1.12/dist/hglib.css"
+
+    _viewconf = t.Dict(allow_none=False).tag(sync=True)
+    _options = t.Dict().tag(sync=True)
+
+    # readonly properties
+    location = t.List(t.Union([t.Float(), t.Tuple()]), read_only=True).tag(sync=True)
+
+    def __init__(self, viewconf: dict, **viewer_options):
+        super().__init__(_viewconf=viewconf, _options=viewer_options)
+
+    def reload(self, *items):
+        msg = json.dumps(["reload", items])
+        self.send(msg)
+
+    def zoom_to(
+        self,
+        view_id: str,
+        start1: int,
+        end1: int,
+        start2: int | None = None,
+        end2: int | None = None,
+        animate_time: int = 500,
+    ):
+        msg = json.dumps(["zoomTo", view_id, start1, end1, start2, end2, animate_time])
+        self.send(msg)

--- a/src/higlass/api.py
+++ b/src/higlass/api.py
@@ -387,7 +387,7 @@ class Viewconf(hgs.Viewconf[View[TrackT]], _PropertiesMixin, Generic[TrackT]):
 
     def widget(self, **kwargs):
         """Create a Jupyter Widget display for this view config."""
-        from higlass_widget import HiGlassWidget
+        from higlass._widget import HiGlassWidget
 
         return HiGlassWidget(self.dict(), **kwargs)
 

--- a/src/higlass/widget.js
+++ b/src/higlass/widget.js
@@ -1,0 +1,41 @@
+import hglib from "https://esm.sh/higlass@1.12?deps=react@17,react-dom@17,pixi.js@6";
+
+/**
+ * @param {{
+ *   xDomain: [number, number],
+ *   yDomain: [number, number],
+ * }} location
+ */
+function toPts({ xDomain, yDomain }) {
+  let [x, xe] = xDomain;
+  let [y, ye] = yDomain;
+  return [x, xe, y, ye];
+}
+
+export async function render({ model, el }) {
+  let viewconf = model.get("_viewconf");
+  let options = model.get("_options") ?? {};
+  let api = await hglib.viewer(el, viewconf, options);
+
+  model.on("msg:custom", (msg) => {
+    msg = JSON.parse(msg);
+    let [fn, ...args] = msg;
+    api[fn](...args);
+  });
+
+  if (viewconf.views.length === 1) {
+    api.on("location", (loc) => {
+      model.set("location", toPts(loc));
+      model.save_changes();
+    }, viewconf.views[0].uid);
+  } else {
+    viewconf.views.forEach((view, idx) => {
+      api.on("location", (loc) => {
+        let copy = model.get("location").slice();
+        copy[idx] = toPts(loc);
+        model.set("location", copy);
+        model.save_changes();
+      }, view.uid);
+    });
+  }
+}


### PR DESCRIPTION
- Moves `higlass-widget` implementation to this repo. 
- Pins ruff version so that we avoid CI randomly failing with new linting rules.