### PR TITLE
Example added for searching using higlass-python

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -182,6 +182,39 @@ or loading an existing view config via URL to access a sub-track:
   # }
 
 
+Add Genome Position SearchBox
+.. code-block:: python
+
+import higlass as hg
+search_box_obj = hg.GenomePositionSearchBox(
+    autocompleteServer="//higlass.io/api/v1",
+    autocompleteId="OHJakQICQD6gTD7skx4EWA",
+    chromInfoId="hg19",
+    chromInfoServer="//higlass.io/api/v1",
+    visible=True)
+
+mm10 = hg.remote(
+    uid="QDutvmyiSrec5nX4pA5WGQ",
+    server="//higlass.io/api/v1",
+)
+
+view1 = hg.view(
+
+    mm10.track("gene-annotations",height=150).opts(
+        minHeight = 24,
+    ),
+    genomePositionSearchBox = search
+)
+
+#In order to get access to track sources from higlass.io data sources
+list_of_track_source_servers = [
+    "//higlass.io/api/v1",
+    "https://resgen.io/api/v1/gt/paper-data"
+  ]
+
+view1.viewconf(trackSourceServers = list_of_track_source_servers, exportViewUrl = "/api/v1/viewconfs")
+
+
 View extent
 -----------
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -185,34 +185,34 @@ or loading an existing view config via URL to access a sub-track:
 Add Genome Position SearchBox
 .. code-block:: python
 
-import higlass as hg
-search_box_obj = hg.GenomePositionSearchBox(
-    autocompleteServer="//higlass.io/api/v1",
-    autocompleteId="OHJakQICQD6gTD7skx4EWA",
-    chromInfoId="hg19",
-    chromInfoServer="//higlass.io/api/v1",
-    visible=True)
-
-mm10 = hg.remote(
-    uid="QDutvmyiSrec5nX4pA5WGQ",
-    server="//higlass.io/api/v1",
-)
-
-view1 = hg.view(
-
-    mm10.track("gene-annotations",height=150).opts(
-        minHeight = 24,
-    ),
-    genomePositionSearchBox = search
-)
-
-#In order to get access to track sources from higlass.io data sources
-list_of_track_source_servers = [
-    "//higlass.io/api/v1",
-    "https://resgen.io/api/v1/gt/paper-data"
-  ]
-
-view1.viewconf(trackSourceServers = list_of_track_source_servers, exportViewUrl = "/api/v1/viewconfs")
+    import higlass as hg
+    search_box_obj = hg.GenomePositionSearchBox(
+        autocompleteServer="//higlass.io/api/v1",
+        autocompleteId="OHJakQICQD6gTD7skx4EWA",
+        chromInfoId="hg19",
+        chromInfoServer="//higlass.io/api/v1",
+        visible=True)
+    
+    mm10 = hg.remote(
+        uid="QDutvmyiSrec5nX4pA5WGQ",
+        server="//higlass.io/api/v1",
+    )
+    
+    view1 = hg.view(
+    
+        mm10.track("gene-annotations",height=150).opts(
+            minHeight = 24,
+        ),
+        genomePositionSearchBox = search
+    )
+    
+    #In order to get access to track sources from higlass.io data sources
+    list_of_track_source_servers = [
+        "//higlass.io/api/v1",
+        "https://resgen.io/api/v1/gt/paper-data"
+      ]
+    
+    view1.viewconf(trackSourceServers = list_of_track_source_servers, exportViewUrl = "/api/v1/viewconfs")
 
 
 View extent

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -192,12 +192,6 @@ Add Genome Position SearchBox
 .. code-block:: python
 
     import higlass as hg
-    search_box_obj = hg.GenomePositionSearchBox(
-        autocompleteServer="//higlass.io/api/v1",
-        autocompleteId="OHJakQICQD6gTD7skx4EWA",
-        chromInfoId="hg19",
-        chromInfoServer="//higlass.io/api/v1",
-        visible=True)
     
     mm10 = hg.remote(
         uid="QDutvmyiSrec5nX4pA5WGQ",
@@ -209,7 +203,12 @@ Add Genome Position SearchBox
         mm10.track("gene-annotations",height=150).opts(
             minHeight = 24,
         ),
-        genomePositionSearchBox = search
+        genomePositionSearchBox = hg.GenomePositionSearchBox(
+            autocompleteServer="//higlass.io/api/v1",
+            autocompleteId="OHJakQICQD6gTD7skx4EWA",
+            chromInfoId="hg19",
+            chromInfoServer="//higlass.io/api/v1",
+            visible=True)
     )
     
     #In order to get access to track sources from higlass.io data sources

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -182,7 +182,13 @@ or loading an existing view config via URL to access a sub-track:
   # }
 
 
+
+
 Add Genome Position SearchBox
+-------------------
+
+
+
 .. code-block:: python
 
     import higlass as hg


### PR DESCRIPTION
## Description

What was changed in this pull request?
This pull request adds an example to get search option on genome wide assembly. Example utilizes dataset of higlass.io

Why is it necessary?
It is necessary because  [hg.Viewconf](https://github.com/higlass/higlass-python/blob/main/src/higlass/api.py#L379C7-L379C15) function and [view.viewconf().json()](https://docs-python.higlass.io/getting_started.html#creating-a-viewconf) have different use cases but have similar alias. 

Along with that, it's very unintuitive to identify usages of view.viewconf() to change viewconfig where we can add/update default arguments for root of viewconfig.

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Update `examples.ipynb` notebook
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
- [ ] Ran `black` on the root directory
