### PR TITLE
feat: Add devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
 	"name": "Python 3.11",
 	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
-	"postCreateCommand": "pipx install hatch && hatch env create"
+	"postCreateCommand": "pipx install hatch",
+	"postStartCommand": "hatch shell"
 }


### PR DESCRIPTION
## Description

Previously, I haven't had a nice setup for introspecting `higlass-python` in a "remote" usage context (beyond ssh-ing onto some remote machine and trying it out). This PR adds a configuration for [VSCode Dev Container](https://code.visualstudio.com/docs/devcontainers/create-dev-container), which bootstraps a development environment in Docker that can be interacted with on the client. I have been using this to "remotely" host a jupyter notebook within the dev container, and then connect in my browser.

As a side note: the `.devcontainer` folder is automatically detected by VS Code, offering new contributors a "one click" environment setup.

![Export-1697820949086](https://github.com/higlass/higlass-python/assets/24403730/22a1aee0-9b8c-4b50-8e7d-c58c77379549)


What was changed in this pull request?

- Adds `.devcontainer/`

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Update `examples.ipynb` notebook
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
- [ ] Ran `black` on the root directory
