### PR TITLE
Migrate to higlass-schema v0.2.0 (pydantic v2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dynamic = ["version"]
 readme = "README.md"
 dependencies = [
     "servir>=0.0.5",
-    "higlass-schema>=0.0.6,<0.2.0",
+    "higlass-schema>=0.2.0",
     "anywidget>=0.9.0",
     "jinja2",
     "jupyter-server-proxy>=3.0",

--- a/src/higlass/_utils.py
+++ b/src/higlass/_utils.py
@@ -75,7 +75,7 @@ ModelT = TypeVar("ModelT", bound=BaseModel)
 
 def copy_unique(model: ModelT) -> ModelT:
     """Creates a deep copy of a pydantic BaseModel with new UID."""
-    copy = model.__class__(**model.dict())
+    copy = model.__class__(**model.model_dump())
     if hasattr(copy, "uid"):
         setattr(copy, "uid", uid())
     return copy

--- a/src/higlass/api.py
+++ b/src/higlass/api.py
@@ -14,29 +14,29 @@ from typing import (
 )
 
 import higlass_schema as hgs
-from pydantic import BaseModel
+from pydantic import RootModel
 
 import higlass._display as display
 import higlass._utils as utils
 
 __all__ = [
+    "CombinedTrack",
     "EnumTrack",
     "HeatmapTrack",
     "IndependentViewportProjectionTrack",
-    "CombinedTrack",
     "PluginTrack",
     "TrackT",
     "View",
     "ViewT",
     "Viewconf",
-    "concat",
-    "hconcat",
-    "vconcat",
-    "track",
-    "view",
     "combine",
+    "concat",
     "divide",
+    "hconcat",
     "lock",
+    "track",
+    "vconcat",
+    "view",
 ]
 
 if TYPE_CHECKING:
@@ -634,7 +634,7 @@ vconcat = functools.partial(concat, "vertical")
 # TODO: register plugins globally to work here?
 
 
-class _TrackCreator(BaseModel):
+class _TrackCreator(RootModel):
     """Create track instances from their track type.
 
     Used internally by `hg.track` to leverage pydantic's ability to get
@@ -642,10 +642,10 @@ class _TrackCreator(BaseModel):
 
     Example:
     -------
-    >>> assert isinstance(_TrackCreator(type="heatmap").__root__, HeatmapTrack)
+    >>> assert isinstance(_TrackCreator(type="heatmap").root, HeatmapTrack)
     """
 
-    __root__: Track
+    root: Track
 
 
 @overload
@@ -688,7 +688,7 @@ def track(
     if uid is None:
         uid = utils.uid()
     data = dict(type=type_, uid=uid, **kwargs)
-    return _TrackCreator.parse_obj(data).__root__
+    return _TrackCreator.model_validate(data).root
 
 
 def view(

--- a/src/higlass/api.py
+++ b/src/higlass/api.py
@@ -383,13 +383,13 @@ class Viewconf(hgs.Viewconf[View[TrackT]], _PropertiesMixin, Generic[TrackT]):
         """ "Displays the view config in an IPython environment."""
         renderer = display.renderers.get()
         plugin_urls = [] if self.views is None else gather_plugin_urls(self.views)
-        return renderer(self.dict(), plugin_urls=plugin_urls)
+        return renderer(self.model_dump(), plugin_urls=plugin_urls)
 
     def widget(self, **kwargs):
         """Create a Jupyter Widget display for this view config."""
         from higlass._widget import HiGlassWidget
 
-        return HiGlassWidget(self.dict(), **kwargs)
+        return HiGlassWidget(self.model_dump(), **kwargs)
 
     @classmethod
     def from_url(cls, url: str, **kwargs):
@@ -416,7 +416,7 @@ class Viewconf(hgs.Viewconf[View[TrackT]], _PropertiesMixin, Generic[TrackT]):
         with urllib.urlopen(request) as response:
             raw = response.read()
 
-        return cls.parse_raw(raw)
+        return cls.model_validate_json(raw)
 
     def locks(
         self,
@@ -745,16 +745,16 @@ def view(
     if layout is None:
         layout = hgs.Layout(x=x, y=y, w=width, h=height)
     else:
-        layout = hgs.Layout(**layout.dict())
+        layout = hgs.Layout(**layout.model_dump())
 
     if tracks is None:
         data = defaultdict(list)
     else:
-        data = defaultdict(list, tracks.dict())
+        data = defaultdict(list, tracks.model_dump())
 
     for track in _tracks:
         if isinstance(track, hgs.Tracks):
-            track = track.dict()
+            track = track.model_dump()
             for position, track_list in track.items():
                 data[position].extend(track_list)
         else:

--- a/src/higlass/api.py
+++ b/src/higlass/api.py
@@ -603,7 +603,7 @@ def concat(
         raise ValueError("concat method must be 'vertical' or 'horizontal'.")
 
     # gather views and adjust layout
-    views = [v.copy(deep=True) for v in b.views]
+    views = [v.model_copy(deep=True) for v in b.views]
     offset = 0 if a.views is None else max(map(mapper, a.views))
     for view in views:
         curr = getattr(view.layout, field)
@@ -616,7 +616,7 @@ def concat(
         locks = getattr(b, lockattr)
         if locks:
             if getattr(a, lockattr) is None:
-                setattr(a, lockattr, locks.copy(deep=True))
+                setattr(a, lockattr, locks.model_copy(deep=True))
             else:
                 getattr(a, lockattr).locksByViewUid.update(locks.locksByViewUid)
                 getattr(a, lockattr).locksDict.update(locks.locksDict)
@@ -806,8 +806,8 @@ def combine(t1: Track, t2: Track, uid: str | None = None, **kwargs) -> CombinedT
         uid = utils.uid()
 
     if isinstance(t1, CombinedTrack):
-        copy = CombinedTrack(**t1.dict())
-        copy.contents.append(t2.__class__(**t2.dict()))
+        copy = CombinedTrack(**t1.model_dump())
+        copy.contents.append(t2.__class__(**t2.model_dump()))
         for key, val in kwargs.items():
             setattr(copy, key, val)
         return copy
@@ -815,7 +815,7 @@ def combine(t1: Track, t2: Track, uid: str | None = None, **kwargs) -> CombinedT
     return CombinedTrack(
         type="combined",
         uid=uid,
-        contents=[track.__class__(**track.dict()) for track in (t1, t2)],
+        contents=[track.__class__(**track.model_dump()) for track in (t1, t2)],
         **kwargs,
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+]
+
+[[package]]
 name = "anyio"
 version = "4.6.2.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -428,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "higlass-python"
-version = "1.1.1.dev7+g0f95bdf.d20241112"
+version = "1.1.3.dev1+g758a156.d20241112"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },
@@ -456,7 +465,7 @@ dev = [
 requires-dist = [
     { name = "anywidget", specifier = ">=0.9.0" },
     { name = "fusepy", marker = "extra == 'fuse'" },
-    { name = "higlass-schema", specifier = ">=0.0.6,<0.2.0" },
+    { name = "higlass-schema", specifier = ">=0.2.0" },
     { name = "jinja2" },
     { name = "jupyter-server-proxy", specifier = ">=3.0" },
     { name = "servir", specifier = ">=0.0.5" },
@@ -474,15 +483,15 @@ dev = [
 
 [[package]]
 name = "higlass-schema"
-version = "0.1.0"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/0b/2ec8e8b0515909bfa8a656cfbd902aa5ed2cd0353f9f25f765344a2dc31a/higlass_schema-0.1.0.tar.gz", hash = "sha256:4d172f03bf5b7cfcfc1f69a661c5dae40166a1aa6ab159251d4b74487586c960", size = 52236 }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/88/4daee43b89395a10ab8c3f772891f23ef5b65825738d3392872761e7aa7b/higlass_schema-0.2.0.tar.gz", hash = "sha256:39cee0af708b6f4a3dd5ef0a4d230d8693bd95289efc700c57c5561c90b987c1", size = 66415 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/66/0a24c53bfb8dd2e2cefbb49dad80bc56b3c769d457c5ef3ee061008bfcc9/higlass_schema-0.1.0-py3-none-any.whl", hash = "sha256:dd5d8273017f9739e62ca6dfc623a393327326e7495864ef91243d5746c04a0a", size = 8377 },
+    { url = "https://files.pythonhosted.org/packages/bb/80/4b392e63e7c7a76878bbce476d65db0059ea4afa1e0d7f03047c9b3e7c5e/higlass_schema-0.2.0-py3-none-any.whl", hash = "sha256:d1d32b4703782492c03769bb0c82b7e13c4657cb67b58fd8419bcddc08a2327c", size = 8680 },
 ]
 
 [[package]]
@@ -1221,14 +1230,39 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "1.10.19"
+version = "2.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/b7/d9e3f12af310e1120c21603644a1cd86f59060e040ec5c3a80b8f05fae30/pydantic-2.9.2.tar.gz", hash = "sha256:d155cef71265d1e9807ed1c32b4c8deec042a44a50a4188b25ac67ecd81a9c0f", size = 769917 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/e4/ba44652d562cbf0bf320e0f3810206149c8a4e99cdbf66da82e97ab53a15/pydantic-2.9.2-py3-none-any.whl", hash = "sha256:f048cec7b26778210e28a0459867920654d48e5e62db0958433636cde4254f12", size = 434928 },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.23.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/2d/df30554721cdad26b241b7a92e726dd1c3716d90c92915731eb00e17a9f7/pydantic-1.10.19.tar.gz", hash = "sha256:fea36c2065b7a1d28c6819cc2e93387b43dd5d3cf5a1e82d8132ee23f36d1f10", size = 355208 }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/aa/6b6a9b9f8537b872f552ddd46dd3da230367754b6f707b8e1e963f515ea3/pydantic_core-2.23.4.tar.gz", hash = "sha256:2584f7cf844ac4d970fba483a717dbe10c1c1c96a969bf65d61ffe94df1b2863", size = 402156 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/68/99ebf43b6b0321175cff0a05f0ce7fa51a8de67d390ccb8ab0d534be86a9/pydantic-1.10.19-py3-none-any.whl", hash = "sha256:2206a1752d9fac011e95ca83926a269fb0ef5536f7e053966d058316e24d929f", size = 165863 },
+    { url = "https://files.pythonhosted.org/packages/ad/ef/16ee2df472bf0e419b6bc68c05bf0145c49247a1095e85cee1463c6a44a1/pydantic_core-2.23.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7530e201d10d7d14abce4fb54cfe5b94a0aefc87da539d0346a484ead376c3cc", size = 1856143 },
+    { url = "https://files.pythonhosted.org/packages/da/fa/bc3dbb83605669a34a93308e297ab22be82dfb9dcf88c6cf4b4f264e0a42/pydantic_core-2.23.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df933278128ea1cd77772673c73954e53a1c95a4fdf41eef97c2b779271bd0bd", size = 1770063 },
+    { url = "https://files.pythonhosted.org/packages/4e/48/e813f3bbd257a712303ebdf55c8dc46f9589ec74b384c9f652597df3288d/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cb3da3fd1b6a5d0279a01877713dbda118a2a4fc6f0d821a57da2e464793f05", size = 1790013 },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/56eda3a37929a1d297fcab1966db8c339023bcca0b64c5a84896db3fcc5c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42c6dcb030aefb668a2b7009c85b27f90e51e6a3b4d5c9bc4c57631292015b0d", size = 1801077 },
+    { url = "https://files.pythonhosted.org/packages/04/be/5e49376769bfbf82486da6c5c1683b891809365c20d7c7e52792ce4c71f3/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:696dd8d674d6ce621ab9d45b205df149399e4bb9aa34102c970b721554828510", size = 1996782 },
+    { url = "https://files.pythonhosted.org/packages/bc/24/e3ee6c04f1d58cc15f37bcc62f32c7478ff55142b7b3e6d42ea374ea427c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2971bb5ffe72cc0f555c13e19b23c85b654dd2a8f7ab493c262071377bfce9f6", size = 2661375 },
+    { url = "https://files.pythonhosted.org/packages/c1/f8/11a9006de4e89d016b8de74ebb1db727dc100608bb1e6bbe9d56a3cbbcce/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8394d940e5d400d04cad4f75c0598665cbb81aecefaca82ca85bd28264af7f9b", size = 2071635 },
+    { url = "https://files.pythonhosted.org/packages/7c/45/bdce5779b59f468bdf262a5bc9eecbae87f271c51aef628d8c073b4b4b4c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0dff76e0602ca7d4cdaacc1ac4c005e0ce0dcfe095d5b5259163a80d3a10d327", size = 1916994 },
+    { url = "https://files.pythonhosted.org/packages/d8/fa/c648308fe711ee1f88192cad6026ab4f925396d1293e8356de7e55be89b5/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7d32706badfe136888bdea71c0def994644e09fff0bfe47441deaed8e96fdbc6", size = 1968877 },
+    { url = "https://files.pythonhosted.org/packages/16/16/b805c74b35607d24d37103007f899abc4880923b04929547ae68d478b7f4/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed541d70698978a20eb63d8c5d72f2cc6d7079d9d90f6b50bad07826f1320f5f", size = 2116814 },
+    { url = "https://files.pythonhosted.org/packages/d1/58/5305e723d9fcdf1c5a655e6a4cc2a07128bf644ff4b1d98daf7a9dbf57da/pydantic_core-2.23.4-cp313-none-win32.whl", hash = "sha256:3d5639516376dce1940ea36edf408c554475369f5da2abd45d44621cb616f769", size = 1738360 },
+    { url = "https://files.pythonhosted.org/packages/a5/ae/e14b0ff8b3f48e02394d8acd911376b7b66e164535687ef7dc24ea03072f/pydantic_core-2.23.4-cp313-none-win_amd64.whl", hash = "sha256:5a1504ad17ba4210df3a045132a7baeeba5a200e930f57512ee02909fc5c4cb5", size = 1919411 },
 ]
 
 [[package]]


### PR DESCRIPTION
Needed to accommodate the pydantic migration in higlass-schema:

- https://github.com/higlass/higlass-schema/pull/16

Staging, until that PR is merged.
