### PR TITLE
Shorter automatic uids

### DIFF
--- a/src/higlass/_utils.py
+++ b/src/higlass/_utils.py
@@ -46,7 +46,7 @@ datatype_default_track = {
 
 
 def uid() -> str:
-    return str(uuid.uuid4())
+    return str(uuid.uuid4()).split("-")[0]
 
 
 T = TypeVar("T")


### PR DESCRIPTION
## Description

What was changed in this pull request?

Shortens the uids from full v4 to the first 8 characters. We don't need the full uuid to uniquely identify tracks/views, and it makes the view configs easier to read.
