### PR TITLE
feat(widget): Suppress right-click event propagation

### DIFF
--- a/src/higlass/_display.py
+++ b/src/higlass/_display.py
@@ -24,11 +24,13 @@ HTML_TEMPLATE = jinja2.Template(
   </body>
   <script type="module">
     import * as hglib from "https://esm.sh/higlass@{{ higlass_version }}?deps=react@{{ react_version }},react-dom@{{ react_version }},pixi.js@{{ pixijs_version }}";
-    hglib.viewer(
-      document.getElementById('{{ output_div }}'),
-      {{ viewconf }},
-    );
-    </script>
+
+    let el = document.getElementById('{{ output_div }}');
+    hglib.viewer(el, {{ viewconf }});
+
+    // prevent right click events from bubbling up to Jupyter/JupyterLab
+    el.addEventListener("contextmenu", (event) => event.stopPropagation());
+  </script>
 </html>
 """  # noqa
 )


### PR DESCRIPTION
JupyterLab captures right-click ("contextmenu") events globally, causing
conflicts with HiGlass's custom context menus when interacting with
anywidget.

This update introduces an `addEventListenersTo` function that prevents
"contextmenu" events from propagating beyond the widget bounds.
Additional event types can be easily added to this function in the
future if needed.

https://github.com/user-attachments/assets/123eda52-826b-4cd9-a863-51436a8eb8b5

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
