### PR TITLE
fix: Use deepcopy instead of model_dump to copy view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [v1.0.2](https://github.com/higlass/higlass-python/compare/v1.0.2...v1.0.1)
 
 - Calculate file pointer hash for track uids for tileset tracks
+- Fix view copy behavior to preserve specific plugin track class vars
 
 ## [v1.0.1](https://github.com/higlass/higlass-python/compare/v1.0.1...v1.0.0)
 

--- a/src/higlass/_utils.py
+++ b/src/higlass/_utils.py
@@ -75,7 +75,7 @@ ModelT = TypeVar("ModelT", bound=BaseModel)
 
 def copy_unique(model: ModelT) -> ModelT:
     """Creates a deep copy of a pydantic BaseModel with new UID."""
-    copy = model.__class__(**model.model_dump())
+    copy = model.model_copy(deep=True)
     if hasattr(copy, "uid"):
         setattr(copy, "uid", uid())
     return copy


### PR DESCRIPTION
## Description

Calling the `.domain()` function on a view creates a copy of the view. The current copy method dumps the view model and creates a new one from the view. Because views expect PluginTrack types instead of specific subclasses, the dumped model does not contain the class vars of the subclasses (e.g. PileupTrack). Switching to `deepcopy` preserves the class vars of the subclasses.

Here's the error that occurs in the added test without this change:

```
                    return pydantic_extra[item]
                except KeyError as exc:
>                   raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}') from exc
E                   AttributeError: 'PluginTrack' object has no attribute 'plugin_url'
```

Fixes #___

## Checklist

- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [x] Updated CHANGELOG.md
