### PR TITLE
docs: Hide overflow in code blocks and scale images

### DIFF
--- a/docs/higlass_theme/static/higlass.css
+++ b/docs/higlass_theme/static/higlass.css
@@ -147,6 +147,11 @@ a:active {
 
 pre, tt, code {
     font-family: 'Roboto Mono', 'Consolas', 'Menlo', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
+    overflow: hidden;
+}
+
+img {
+    width: 100%;
 }
 
 div.document {


### PR DESCRIPTION
## Description

Fix docs formatting to go from this:

<img width="1039" alt="image" src="https://github.com/user-attachments/assets/2d699c76-81db-48d6-939f-fa93732fac2f" />

To this:

<img width="791" alt="image" src="https://github.com/user-attachments/assets/cba09cba-0056-46e7-9257-d25c4b90d764" />

This is necessary to keep the docs aesthetically pleasing.

Fixes #___

## Checklist

- [ ] **Clear PR title** (used for generating release notes).
   - Prefer using prefixes like `fix:` or `feat:` to help organize auto-generated notes.
- [ ] **Unit tests** added or updated.
- [x] **Documentation** added or updated.
