### PR TITLE
fix: Make sure the sidebar stays up top in the docs on wide screens

### DIFF
--- a/docs/higlass_theme/static/higlass.css
+++ b/docs/higlass_theme/static/higlass.css
@@ -670,3 +670,25 @@ div.document {
     display: none;
   }
 }
+
+@media screen and (min-width: 940px) {
+  div.sphinxsidebar {
+    max-height: 100%;
+    overflow-y: auto;
+    position: absolute;
+    top: 100px;
+  }
+}
+
+@media screen and (max-width: 940px) {
+  div.sphinxsidebar {
+    display: block;
+    float: none;
+    width: unset;
+    margin: 50px -30px -20px -30px;
+    padding: 10px 20px;
+    background: #333;
+    color: #fff;
+    position: static;
+  }
+}


### PR DESCRIPTION
## Description

Make sure the sidebar stays up top in the docs:

<img width="643" alt="image" src="https://github.com/user-attachments/assets/95078021-f78b-4bea-99e6-8a7ef5e1fe82" />

Compare that to the current situation at https://docs-python.higlass.io/getting_started.html#creating-a-viewconf where the sidebar is at the bottom.

Fixes #___

## Checklist

- [ ] **Clear PR title** (used for generating release notes).
   - Prefer using prefixes like `fix:` or `feat:` to help organize auto-generated notes.
- [ ] **Unit tests** added or updated.
- [x] **Documentation** added or updated.
