### PR TITLE
docs: fix Sphinx warnings and allow scroll for code snippets 

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -185,7 +185,7 @@ or loading an existing view config via URL to access a sub-track:
 
 
 Add Genome Position SearchBox
--------------------
+-----------------------------
 
 
 
@@ -458,7 +458,7 @@ that may take a long time to complete with a slow internet connection.
 
 For a better user experience, we recommend downloading the data locally first.
 
-.. code-block:: python
+.. code-block:: bash
 
     !wget http://hgdownload.cse.ucsc.edu/goldenpath/hg19/encodeDCC/wgEncodeSydhTfbs/wgEncodeSydhTfbsGm12878InputStdSig.bigWig
 

--- a/docs/higlass_theme/static/higlass.css
+++ b/docs/higlass_theme/static/higlass.css
@@ -147,7 +147,7 @@ a:active {
 
 pre, tt, code {
     font-family: 'Roboto Mono', 'Consolas', 'Menlo', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
-    overflow: hidden;
+    overflow: scroll;
 }
 
 img {


### PR DESCRIPTION
Just some little nits. There are some warnings from Sphinx and the css lets you actually scroll the text when it overflows in y.

- **Fix sphinx warnings**
- **Set `overflow: scroll` for code snippets**

## Description

What was changed in this pull request?

Why is it necessary?

Fixes #___

## Checklist

- [ ] **Clear PR title** (used for generating release notes).
   - Prefer using prefixes like `fix:` or `feat:` to help organize auto-generated notes.
- [ ] **Unit tests** added or updated.
- [x] **Documentation** added or updated.
