### PR TITLE
Replace `higlass.tilesets.register` with `higlass.Tileset`

### DIFF
--- a/examples/JupyterServer.ipynb
+++ b/examples/JupyterServer.ipynb
@@ -30,8 +30,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from clodius.tiles.cooler import tiles, tileset_info\n",
     "from dataclasses import dataclass\n",
+    "\n",
+    "from clodius.tiles.cooler import tiles, tileset_info\n",
+    "\n",
     "\n",
     "@dataclass\n",
     "class MyCustomCoolerTileset(hg.Tileset):\n",
@@ -43,6 +45,7 @@
     "\n",
     "    def info(self):\n",
     "        return tileset_info(self.path)\n",
+    "\n",
     "\n",
     "ts = MyCustomCoolerTileset(\"test.mcool\")\n",
     "hg.view(ts.track())"

--- a/examples/JupyterServer.ipynb
+++ b/examples/JupyterServer.ipynb
@@ -29,7 +29,24 @@
    "id": "2e2c753f-fb13-4d54-b031-10cf5865e138",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from clodius.tiles.cooler import tiles, tileset_info\n",
+    "from dataclasses import dataclass\n",
+    "\n",
+    "@dataclass\n",
+    "class MyCustomCoolerTileset(hg.Tileset):\n",
+    "    path: str\n",
+    "    datatype = \"matrix\"\n",
+    "\n",
+    "    def tiles(self, tile_ids):\n",
+    "        return tiles(self.path, tile_ids)\n",
+    "\n",
+    "    def info(self):\n",
+    "        return tileset_info(self.path)\n",
+    "\n",
+    "ts = MyCustomCoolerTileset(\"test.mcool\")\n",
+    "hg.view(ts.track())"
+   ]
   },
   {
    "cell_type": "code",

--- a/src/higlass/__init__.py
+++ b/src/higlass/__init__.py
@@ -10,6 +10,32 @@ except PackageNotFoundError:
 
 from higlass_schema import *
 
-import higlass.tilesets as tilesets
-from higlass.api import *
-from higlass.tilesets import bed2ddb, beddb, bigwig, cooler, hitile, multivec, remote
+from higlass.api import (
+    CombinedTrack,
+    EnumTrack,
+    HeatmapTrack,
+    IndependentViewportProjectionTrack,
+    PluginTrack,
+    TrackT,
+    View,
+    Viewconf,
+    ViewT,
+    combine,
+    concat,
+    divide,
+    hconcat,
+    lock,
+    track,
+    vconcat,
+    view,
+)
+from higlass.tilesets import (
+    Tileset,
+    bed2ddb,
+    beddb,
+    bigwig,
+    cooler,
+    hitile,
+    multivec,
+    remote,
+)

--- a/src/higlass/api.py
+++ b/src/higlass/api.py
@@ -121,46 +121,16 @@ class _OptionsMixin:
         return track
 
 
-class _TilesetMixin:
-    def tileset(
-        self: TrackT,  # type: ignore
-        tileset: TrackHelper,
-        inplace: bool = False,
-    ) -> TrackT:  # type: ignore
-        """Replace or add a tileset to a Track.
-
-        A convenience method to update a track with a tileset.
-
-        Parameters
-        ----------
-        tileset : TilesetResource
-            A tileset resource returned from `hg.server`.
-
-        inplace : bool, optional
-            Whether to modify the existing track in place or return
-            a new track (default: `False`)
-
-        Returns
-        -------
-        track : A track with the bound tileset.
-
-        """
-        track = self if inplace else utils.copy_unique(self)
-        track.server = tileset.server
-        track.tilesetUid = tileset.tileset.uid
-        return track
-
-
 ## Extend higlass-schema classes
 
 
-class EnumTrack(hgs.EnumTrack, _OptionsMixin, _PropertiesMixin, _TilesetMixin):
+class EnumTrack(hgs.EnumTrack, _OptionsMixin, _PropertiesMixin):
     """Represents a generic track."""
 
     ...
 
 
-class HeatmapTrack(hgs.HeatmapTrack, _OptionsMixin, _PropertiesMixin, _TilesetMixin):
+class HeatmapTrack(hgs.HeatmapTrack, _OptionsMixin, _PropertiesMixin):
     """Represets a specialized heatmap track."""
 
     ...
@@ -170,20 +140,19 @@ class IndependentViewportProjectionTrack(
     hgs.IndependentViewportProjectionTrack,
     _OptionsMixin,
     _PropertiesMixin,
-    _TilesetMixin,
 ):
     """Represents a view-independent viewport projection track."""
 
     ...
 
 
-class CombinedTrack(hgs.CombinedTrack, _OptionsMixin, _PropertiesMixin, _TilesetMixin):
+class CombinedTrack(hgs.CombinedTrack, _OptionsMixin, _PropertiesMixin):
     """Represents a track combining multiple tracks."""
 
     ...
 
 
-class PluginTrack(hgs.BaseTrack, _OptionsMixin, _PropertiesMixin, _TilesetMixin):
+class PluginTrack(hgs.BaseTrack, _OptionsMixin, _PropertiesMixin):
     """Represents an unknown plugin track."""
 
     plugin_url: ClassVar[str]

--- a/src/higlass/api.py
+++ b/src/higlass/api.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 from collections import defaultdict
 from typing import (
-    TYPE_CHECKING,
     ClassVar,
     Generic,
     Literal,
@@ -38,8 +37,6 @@ __all__ = [
     "view",
 ]
 
-if TYPE_CHECKING:
-    from higlass._track_helper import TrackHelper
 
 ## Mixins
 

--- a/src/higlass/tilesets.py
+++ b/src/higlass/tilesets.py
@@ -72,6 +72,45 @@ def remote(
 
 
 class Tileset(abc.ABC):
+    """Base class for defining custom tilesets in `higlass`.
+
+    Subclasses must implement the `tiles` and `info` methods.
+
+    The provided `track` method is a helper which automatically registers the
+    tileset with the `TilesetRegistry` and returns a HiGlass track object
+    ready for visualization.
+
+    Parameters
+    ----------
+    klass : type[T]
+        A class implementing `TilesetProtocol`.
+
+    Returns
+    -------
+    type[T]
+        The input class, now with an added `track` method.
+
+    Examples
+    --------
+    >>> import higlass as hg
+    >>> from dataclasses import dataclass
+    >>> from clodius.tiles import cooler
+    >>>
+    >>> @dataclass
+    >>> class MyCoolerTileset(hg.Tileset):
+    >>>     filepath: str
+    >>>     datatype = "matrix"
+    >>>
+    >>>     def info(self):
+    >>>         return tileset_info(self.filepath)
+    >>>
+    >>>     def tiles(self, tile_ids):
+    >>>         return tiles(self.filepath, tile_ids)
+    >>>
+    >>> tileset = MyCoolerTileset("test.mcool")
+    >>> hg.view(tileset.track("heatmap"))
+    """
+
     @abc.abstractmethod
     def tiles(self, tile_ids: typing.Sequence[str], /) -> list[dict]: ...
 

--- a/src/higlass/tilesets.py
+++ b/src/higlass/tilesets.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
+import abc
 import functools
 import pathlib
 import typing
 from dataclasses import dataclass
 
 import higlass.api
-from higlass._tileset_registry import TilesetInfo, TilesetProtocol, TilesetRegistry
+from higlass._tileset_registry import TilesetInfo, TilesetRegistry
 from higlass._utils import TrackType, datatype_default_track
 
 __all__ = [
+    "Tileset",
     "bed2ddb",
     "bigwig",
     "cooler",
     "hitile",
     "multivec",
-    "register",
     "remote",
 ]
 
@@ -28,91 +29,6 @@ DataType = typing.Literal[
     "multivec",
     "vector",
 ]
-
-T = typing.TypeVar("T", bound=TilesetProtocol)
-
-
-def register(klass: type[T]) -> type[T]:
-    """Decorator that adds a `track` method to a class implementing `TilesetProtocol`.
-
-    The `track` method automatically registers the tileset with the `TilesetRegistry`
-    and returns a HiGlass track object, which can be used for visualization.
-
-    Parameters
-    ----------
-    klass : type[T]
-        A class that implements `TilesetProtocol`.
-
-    Returns
-    -------
-    type[T]
-        The input class, now with an added `track` method.
-
-    Examples
-    --------
-    >>> from dataclasses import dataclass
-    >>> from clodius.tiles.cooler import tiles, tileset_info
-    >>>
-    >>> @register
-    >>> @dataclass
-    >>> class MyCoolerTileset:
-    >>>     filepath: str
-    >>>     datatype = "matrix"
-    >>>
-    >>>     def info(self):
-    >>>         return tileset_info(self.filepath)
-    >>>
-    >>>     def tiles(self, tile_ids):
-    >>>         return tiles(self.filepath, tile_ids)
-    >>>
-    >>> tileset = MyCoolerTileset("test.mcool")
-    >>> track = tileset.track("heatmap")
-    """
-
-    def track(
-        self: TilesetProtocol, type_: TrackType | None = None, /, **kwargs
-    ) -> higlass.api.Track:
-        """
-        Create a HiGlass track for the tileset.
-
-        Registers the tileset with the `TilesetRegistry` and returns a track
-        of the given `type_`. Defaults to a type based on the tileset's `datatype`
-        if not specified.
-
-        Parameters
-        ----------
-        type_ : TrackType, optional
-            Track type. If `None`, a default is inferred.
-
-        Returns
-        -------
-        higlass.api.Track
-            The configured HiGlass track.
-        """
-        # use default track based on datatype if available
-        if type_ is None:
-            datatype = getattr(self, "datatype", None)
-            if datatype is None:
-                raise ValueError("No default track for tileset")
-            else:
-                type_ = typing.cast(TrackType, datatype_default_track[datatype])
-
-        # add tileset registry and get an identifier
-        uid = TilesetRegistry.add(self)
-        track = higlass.api.track(
-            type_=type_,
-            server="jupyter",
-            tilesetUid=uid,
-            **kwargs,
-        )
-        name = getattr(self, "name", None)
-        if name is not None:
-            track.opts(name=name, inplace=True)
-
-        return track
-
-    setattr(klass, "track", track)
-    return klass
 
 
 @dataclass
@@ -155,9 +71,56 @@ def remote(
     return RemoteTileset(uid, server, name)
 
 
-@register
+class Tileset(abc.ABC):
+    @abc.abstractmethod
+    def tiles(self, tile_ids: typing.Sequence[str], /) -> list[dict]: ...
+
+    @abc.abstractmethod
+    def info(self) -> TilesetInfo: ...
+
+    def track(self, type_: TrackType | None = None, /, **kwargs) -> higlass.api.Track:
+        """
+        Create a HiGlass track for the tileset.
+
+        Registers the tileset with the `TilesetRegistry` and returns a track
+        of the given `type_`. Defaults to a type based on the tileset's `datatype`
+        if not specified.
+
+        Parameters
+        ----------
+        type_ : TrackType, optional
+            Track type. If `None`, a default is inferred.
+
+        Returns
+        -------
+        higlass.api.Track
+            The configured HiGlass track.
+        """
+        # use default track based on datatype if available
+        if type_ is None:
+            datatype = getattr(self, "datatype", None)
+            if datatype is None:
+                raise ValueError("No default track for tileset")
+            else:
+                type_ = typing.cast(TrackType, datatype_default_track[datatype])
+
+        # add tileset registry and get an identifier
+        uid = TilesetRegistry.add(self)
+        track = higlass.api.track(
+            type_=type_,
+            server="jupyter",
+            tilesetUid=uid,
+            **kwargs,
+        )
+        name = getattr(self, "name", None)
+        if name is not None:
+            track.opts(name=name, inplace=True)
+
+        return track
+
+
 @dataclass
-class ClodiusTileset(TilesetProtocol):
+class ClodiusTileset(Tileset):
     datatype: DataType
     tiles_impl: typing.Callable[[typing.Sequence[str]], list[typing.Any]]
     info_impl: typing.Callable[[], TilesetInfo]

--- a/test/test_tileset_registery.py
+++ b/test/test_tileset_registery.py
@@ -5,7 +5,7 @@ import typing
 import pytest
 
 from higlass._tileset_registry import TilesetRegistry
-from higlass.tilesets import ClodiusTileset, register
+from higlass.tilesets import ClodiusTileset, Tileset
 
 
 def mock_tileset() -> ClodiusTileset:
@@ -42,8 +42,7 @@ def test_tilesets_are_weakly_referenced(Registry: type[TilesetRegistry]) -> None
 
 
 def test_custom_tileset_without_uid(Registry: type[TilesetRegistry]) -> None:
-    @register
-    class MyTileset:
+    class MyTileset(Tileset):
         def tiles(self, tile_ids: typing.Sequence[str]) -> list[typing.Any]:
             return []
 


### PR DESCRIPTION
The `register` naming is not very clear, and also the meta-programming
in the previous approach erased type information. By having a shared
based class, implementing a custom tileset is much nicer:

```py
from dataclasses import dataclass

import higlass as hg
from clodius.tiles import cooler

@dataclass
class MyCustomCoolerTileset(hg.Tileset):
    path: str
    datatype = "matrix"

    def tiles(self, tile_ids):
        return cooler.tiles(self.path, tile_ids)

    def info(self):
        return cooler.tileset_info(self.path)

ts = MyCustomCoolerTileset("test.mcool")
hg.view(ts.track())
```

## Description

What was changed in this pull request?

Why is it necessary?

Fixes #___

## Checklist

- [ ] **Clear PR title** (used for generating release notes).
  - Prefer using prefixes like `fix:` or `feat:` to help organize auto-generated
    notes.
- [ ] **Unit tests** added or updated.
- [ ] **Documentation** added or updated.
