### PR TITLE
feat(widget): Batch tile requests within an animation frame

### DIFF
--- a/src/higlass/types.ts
+++ b/src/higlass/types.ts
@@ -70,7 +70,7 @@ export type HGC = {
     tileResponseToData<T>(
       inputData: Record<string, T>,
       server: string,
-      theseTileIds: Array<string>,
+      tileIds: Array<string>,
     ): Record<string, unknown>;
   };
 };

--- a/src/higlass/widget.js
+++ b/src/higlass/widget.js
@@ -4,6 +4,7 @@ import { v4 } from "https://esm.sh/@lukeed/uuid@2.0.1";
 /** @import { HGC, PluginDataFetcherConstructor, GenomicLocation, Viewconf, DataFetcher} from "./types.ts" */
 
 const NAME = "jupyter";
+const MAX_TILES_PER_REQUEST = 20;
 
 /**
  * @param {string} href
@@ -210,7 +211,7 @@ async function registerJupyterHiGlassDataFetcher(model) {
             Array.from(
               chunkIterable(
                 new Set(requests.flatMap((r) => r.data.tileIds)),
-                20,
+                MAX_TILES_PER_REQUEST,
               ),
               async (tileIds) => {
                 let response = await sendCustomMessage(tModel, {

--- a/src/higlass/widget.js
+++ b/src/higlass/widget.js
@@ -357,24 +357,10 @@ function consolidator(processBatch) {
 
   return function enqueue(data) {
     id = id || requestAnimationFrame(() => run());
-    let { promise, resolve, reject } = /** @type {typeof defer<U>} */ (defer)();
+    let { promise, resolve, reject } = Promise.withResolvers();
     pending.push({ data, resolve, reject });
     return promise;
   };
-}
-
-/**
- * @template T
- * @returns {{ promise: Promise<T>, resolve: (success: T) => void, reject: (err: unknown) => void }}
- */
-function defer() {
-  let resolve, reject;
-  let promise = new Promise((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  // @ts-expect-error - can replace `Promise.withResolvers` in the future
-  return { promise, resolve, reject };
 }
 
 /**


### PR DESCRIPTION
HiGlass's built-in data fetching logic is designed to optimize API calls
by consolidating requests based on time, ID, and server. Our custom
Jupyter data fetcher doesn't include these optimizations.

This PR introduces a `consolidator` helper, which performs a much simpler
form of batching. Since we assume a single server, this function only
batches tile requests that occur within the same animation frame and
submits them together. This helps reduce the number of comms calls, and
at a minimum dedupes requests with the same tile id.

This is the approach taken in [mosaic](https://idl.cs.washington.edu/files/2024-Mosaic-TVCG.pdf): 

> "As multiple queries tend to be issued in tandem (for example upon
initialization), the Coordinator waits one animation frame, collects
incoming queries, and merges those .... Upon query completion, 
the Coordinator parcels out appropriate projections to clients."

Initial testing suggests it feels quite responsive!

**Before** (slight lag due to repeated (shared) requests)

![Screen Recording 2025-02-20 at 22 45 33](https://github.com/user-attachments/assets/5474c9ae-fec5-4492-b39c-5a567c1cd4ad)

**After** 

![Screen Recording 2025-02-20 at 22 47 14](https://github.com/user-attachments/assets/16aaaa54-20cf-41ef-b62d-4d509ce5e80d)


## Checklist

- [x] **Clear PR title** (used for generating release notes).
  - Prefer using prefixes like `fix:` or `feat:` to help organize auto-generated
    notes.
- [ ] **Unit tests** added or updated.
- [ ] **Documentation** added or updated.
