### PR TITLE
Fix page scrolling when using mouse wheel to zoom in Jupyter notebooks

### DIFF
--- a/src/higlass/widget.js
+++ b/src/higlass/widget.js
@@ -273,6 +273,12 @@ function addEventListenersTo(el) {
     signal: controller.signal,
   });
 
+  // prevent wheel events from scrolling the page while allowing HiGlass zoom
+  el.addEventListener("wheel", (event) => event.stopPropagation(), {
+    signal: controller.signal,
+    passive: false,
+  });
+
   return () => controller.abort();
 }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where scrolling the mouse wheel to zoom in the HiGlass widget would also scroll the Jupyter notebook page, particularly noticeable when running notebooks in VS Code.

## Changes

- Added a `wheel` event listener to the widget container that calls `stopPropagation()` to prevent the event from bubbling up to the notebook page
- Set `passive: false` to ensure the event handler can properly intercept wheel events

## Testing

- Tested in VS Code with Jupyter notebooks
- Verified that mouse wheel zoom works correctly in the HiGlass widget
- Confirmed that the notebook page no longer scrolls when zooming the widget

## Technical Details

The fix is implemented in `src/higlass/widget.js` in the `addEventListenersTo()` function, following the same pattern as the existing `contextmenu` event handler. This approach ensures wheel events are handled at the widget level before they can trigger page scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)